### PR TITLE
Add JSON Converter for iRacing Durations & Use As Appropriate

### DIFF
--- a/src/Aydsko.iRacingData.UnitTests/Converters/JsonConverterTestExtensions.cs
+++ b/src/Aydsko.iRacingData.UnitTests/Converters/JsonConverterTestExtensions.cs
@@ -1,0 +1,69 @@
+﻿// © 2022 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Aydsko.iRacingData.UnitTests.Converters;
+
+public static class JsonConverterTestExtensions
+{
+    private const string InvalidJsonObjectInputFormatMessage = "Expected input to be in the format \"{\"value\":\"(INPUT TO BE TESTED)\"}\" or \"{\"value\":(INPUT TO BE TESTED)}\" where (INPUT TO BE TESTED) was replaced with the value to be tested.";
+
+#pragma warning disable CA1062 // Validate arguments of public methods - check done with "!!" operator
+
+    public static IEnumerable<TestCaseData> ToReadValueTestCases<T>(this IEnumerable<(byte[] JsonBytes, T Value, string Name)> examples!!)
+    {
+        foreach (var (jsonValueBytes, timeValue, name) in examples)
+        {
+            yield return new TestCaseData(new object[] { jsonValueBytes }).Returns(timeValue).SetName("Read Value: " + name);
+        }
+    }
+
+    public static IEnumerable<TestCaseData> ToWriteValueTestCases<T>(this IEnumerable<(byte[] JsonBytes, T Value, string Name)> examples!!)
+    {
+        foreach (var (jsonValueBytes, timeValue, name) in examples)
+        {
+            yield return new TestCaseData(timeValue).Returns(jsonValueBytes).SetName("Write Value: " + name);
+        }
+    }
+
+    public static Utf8JsonReader ToUtf8JsonReaderForTest(this byte[] input!!)
+    {
+        var reader = new Utf8JsonReader(input.AsSpan());
+
+        if (!(reader.Read() && reader.TokenType == JsonTokenType.StartObject))
+        {
+            throw new ArgumentException(InvalidJsonObjectInputFormatMessage);
+        }
+
+        if (!(reader.Read() && reader.TokenType == JsonTokenType.PropertyName))
+        {
+            throw new ArgumentException(InvalidJsonObjectInputFormatMessage);
+        }
+
+        if (!(reader.Read() && (reader.TokenType == JsonTokenType.String || reader.TokenType == JsonTokenType.Number || reader.TokenType == JsonTokenType.Null)))
+        {
+            throw new ArgumentException(InvalidJsonObjectInputFormatMessage);
+        }
+
+        return reader;
+    }
+
+    public static byte[] WriteUsingConverter<T>(this T input, JsonConverter<T> converter!!)
+    {
+        using var outputStream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(outputStream))
+        {
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("value");
+            converter.Write(writer, input, new JsonSerializerOptions());
+            writer.WriteEndObject();
+        }
+
+        return outputStream.ToArray();
+    }
+
+#pragma warning restore CA1062 // Validate arguments of public methods
+}

--- a/src/Aydsko.iRacingData.UnitTests/Converters/TenThousandthSecondDurationConverterTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/Converters/TenThousandthSecondDurationConverterTests.cs
@@ -1,0 +1,45 @@
+﻿// © 2022 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+using Aydsko.iRacingData.Converters;
+using System.Text;
+using System.Text.Json;
+
+namespace Aydsko.iRacingData.UnitTests.Converters;
+public class TenThousandthSecondDurationConverterTests
+{
+    private TenThousandthSecondDurationConverter _sut = null!;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        // There is no state in the converter so it only needs to be created once for each set of test runs.
+        _sut = new TenThousandthSecondDurationConverter();
+    }
+
+    [Test, TestCaseSource(nameof(ReadValueTestCases))]
+    public TimeSpan? ReadValue(byte[] input)
+    {
+        var reader = input.ToUtf8JsonReaderForTest();
+        return _sut.Read(ref reader, typeof(TimeSpan?), new JsonSerializerOptions());
+    }
+
+    [Test, TestCaseSource(nameof(WriteValueTestCases))]
+    public byte[] WriteValue(TimeSpan? input)
+    {
+        var result = input.WriteUsingConverter(_sut);
+        Console.WriteLine(Encoding.UTF8.GetString(result));
+        return result;
+    }
+
+    public static IEnumerable<TestCaseData> ReadValueTestCases() => Examples().ToReadValueTestCases();
+    public static IEnumerable<TestCaseData> WriteValueTestCases() => Examples().ToWriteValueTestCases();
+
+    private static IEnumerable<(byte[] JsonBytes, TimeSpan? Value, string Name)> Examples()
+    {
+        yield return (Encoding.UTF8.GetBytes(@"{""value"":834560}"), new TimeSpan(0, 0, 1, 23, 456), "834560 / 1:23.456");
+        yield return (Encoding.UTF8.GetBytes(@"{""value"":0}"), TimeSpan.Zero, "0 / 0:00.000");
+        yield return (Encoding.UTF8.GetBytes(@"{""value"":null}"), null, "null / null");
+        yield return (Encoding.UTF8.GetBytes(@"{""value"":600000}"), new TimeSpan(0, 0, 1, 0, 0), "600000 / 1:00.000");
+    }
+}

--- a/src/Aydsko.iRacingData/Converters/TenThousandthSecondDurationConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/TenThousandthSecondDurationConverter.cs
@@ -1,0 +1,47 @@
+﻿// © 2022 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Aydsko.iRacingData.Converters;
+
+/// <summary>
+/// The raw iRacing API results use a number type which carries duration values to the ten-thousandth of a second.
+/// So, for example, a lap which was displayed in the iRacing results page as &quot;1:23.456&quot; would be returned as &quot;834560&quot;.
+/// </summary>
+public class TenThousandthSecondDurationConverter : JsonConverter<TimeSpan?>
+{
+    public override TimeSpan? Read(ref Utf8JsonReader reader,
+                                        Type typeToConvert,
+                                        JsonSerializerOptions options)
+    {
+        long? value = reader switch
+        {
+            { TokenType: JsonTokenType.String } when long.TryParse(reader.GetString(), out var valueFromString) => valueFromString,
+            { TokenType: JsonTokenType.Number } when reader.TryGetInt64(out var valueFromNumber) => valueFromNumber,
+            _ => null,
+        };
+
+        if (value is null)
+        {
+            return null;
+        }
+
+        return TimeSpan.FromSeconds(value.Value / 10000D); // iRacing reports to the ten-thousandth & this is the easiest way to parse out.
+    }
+
+    public override void Write(Utf8JsonWriter writer!!,
+                               TimeSpan? value,
+                               JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            var millisValue = (long)(value.Value.TotalSeconds * 10000);
+            writer.WriteNumberValue(millisValue);
+        }
+    }
+}

--- a/src/Aydsko.iRacingData/Package Release Notes.txt
+++ b/src/Aydsko.iRacingData/Package Release Notes.txt
@@ -1,10 +1,7 @@
 ﻿New iRacing Endpoints:
 
- - stats/season_qualify_results
- - stats/season_tt_results
- - stats/season_tt_standings
- - stats/season_team_standings
+ - ???
 
 Fixes:
 
- - Add ability to handle a "Forbidden" response
+ - Fields that are durations (e.g. lap times or intervals) will use the "TimeSpan" data type

--- a/src/Aydsko.iRacingData/Results/Result.cs
+++ b/src/Aydsko.iRacingData/Results/Result.cs
@@ -1,6 +1,7 @@
 ﻿// © 2022 Adrian Clark
 // This file is licensed to you under the MIT license.
 
+using Aydsko.iRacingData.Converters;
 using System.Text.Json.Serialization;
 
 namespace Aydsko.iRacingData.Results;
@@ -9,7 +10,7 @@ public class Result
 {
 
     [JsonPropertyName("cust_id")]
-    public int CustId { get; set; }
+    public int CustomerId { get; set; }
 
     [JsonPropertyName("display_name")]
     public string DisplayName { get; set; } = default!;
@@ -29,35 +30,35 @@ public class Result
     [JsonPropertyName("opt_laps_complete")]
     public int OptLapsComplete { get; set; }
 
-    [JsonPropertyName("interval")]
-    public int Interval { get; set; }
+    [JsonPropertyName("interval"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? Interval { get; set; }
 
-    [JsonPropertyName("class_interval")]
-    public int ClassInterval { get; set; }
+    [JsonPropertyName("class_interval"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? ClassInterval { get; set; }
 
-    [JsonPropertyName("average_lap")]
-    public int AverageLap { get; set; }
+    [JsonPropertyName("average_lap"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? AverageLap { get; set; }
 
     [JsonPropertyName("best_lap_num")]
-    public int BestLapNum { get; set; }
+    public int BestLapNumber { get; set; }
 
-    [JsonPropertyName("best_lap_time")]
-    public int BestLapTime { get; set; }
+    [JsonPropertyName("best_lap_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? BestLapTime { get; set; }
 
     [JsonPropertyName("best_nlaps_num")]
     public int BestNlapsNum { get; set; }
 
-    [JsonPropertyName("best_nlaps_time")]
-    public int BestNlapsTime { get; set; }
+    [JsonPropertyName("best_nlaps_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? BestNlapsTime { get; set; }
 
     [JsonPropertyName("best_qual_lap_at")]
-    public DateTime BestQualLapAt { get; set; }
+    public DateTime BestQualifyingLapAt { get; set; }
 
     [JsonPropertyName("best_qual_lap_num")]
-    public int BestQualLapNum { get; set; }
+    public int BestQualifyingLapNum { get; set; }
 
-    [JsonPropertyName("best_qual_lap_time")]
-    public int BestQualLapTime { get; set; }
+    [JsonPropertyName("best_qual_lap_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? BestQualifyingLapTime { get; set; }
 
     [JsonPropertyName("reason_out_id")]
     public int ReasonOutId { get; set; }
@@ -77,8 +78,8 @@ public class Result
     [JsonPropertyName("position")]
     public int Position { get; set; }
 
-    [JsonPropertyName("qual_lap_time")]
-    public int QualLapTime { get; set; }
+    [JsonPropertyName("qual_lap_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? QualifyingLapTime { get; set; }
 
     [JsonPropertyName("starting_position")]
     public int StartingPosition { get; set; }
@@ -160,7 +161,7 @@ public class Result
     public int Incidents { get; set; }
 
     [JsonPropertyName("max_pct_fuel_fill")]
-    public int MaxPctFuelFill { get; set; }
+    public int MaxPercentFuelFill { get; set; }
 
     [JsonPropertyName("weight_penalty_kg")]
     public int WeightPenaltyKg { get; set; }
@@ -169,7 +170,7 @@ public class Result
     public int LeaguePoints { get; set; }
 
     [JsonPropertyName("league_agg_points")]
-    public int LeagueAggPoints { get; set; }
+    public int LeagueAggregatePoints { get; set; }
 
     [JsonPropertyName("car_id")]
     public int CarId { get; set; }

--- a/src/Aydsko.iRacingData/Results/SeasonRaceResult.cs
+++ b/src/Aydsko.iRacingData/Results/SeasonRaceResult.cs
@@ -1,0 +1,51 @@
+﻿// © 2022 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+using Aydsko.iRacingData.Converters;
+
+namespace Aydsko.iRacingData.Results;
+
+public class SeasonRaceResult
+{
+    [JsonPropertyName("race_week_num")]
+    public int RaceWeekNum { get; set; }
+
+    [JsonPropertyName("event_type")]
+    public EventType EventType { get; set; }
+
+    [JsonPropertyName("event_type_name")]
+    public string? EventTypeName { get; set; }
+
+    [JsonPropertyName("start_time")]
+    public DateTime StartTime { get; set; }
+
+    [JsonPropertyName("session_id")]
+    public int SessionId { get; set; }
+
+    [JsonPropertyName("subsession_id")]
+    public int SubsessionId { get; set; }
+
+    [JsonPropertyName("official_session")]
+    public bool OfficialSession { get; set; }
+
+    [JsonPropertyName("event_strength_of_field")]
+    public int EventStrengthOfField { get; set; }
+
+    [JsonPropertyName("event_best_lap_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? EventBestLapTime { get; set; }
+
+    [JsonPropertyName("num_cautions")]
+    public int NumCautions { get; set; }
+
+    [JsonPropertyName("num_caution_laps")]
+    public int NumCautionLaps { get; set; }
+
+    [JsonPropertyName("num_lead_changes")]
+    public int NumLeadChanges { get; set; }
+
+    [JsonPropertyName("num_drivers")]
+    public int NumDrivers { get; set; }
+
+    [JsonPropertyName("track")]
+    public SeasonResultTrack Track { get; set; } = null!;
+}

--- a/src/Aydsko.iRacingData/Results/SeasonResultTrack.cs
+++ b/src/Aydsko.iRacingData/Results/SeasonResultTrack.cs
@@ -1,0 +1,16 @@
+﻿// © 2022 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.Results;
+
+public class SeasonResultTrack
+{
+    [JsonPropertyName("track_id")]
+    public int TrackId { get; set; }
+
+    [JsonPropertyName("track_name")]
+    public string? TrackName { get; set; }
+
+    [JsonPropertyName("config_name")]
+    public string? ConfigName { get; set; }
+}

--- a/src/Aydsko.iRacingData/Results/SeasonResults.cs
+++ b/src/Aydsko.iRacingData/Results/SeasonResults.cs
@@ -1,7 +1,7 @@
 ﻿// © 2022 Adrian Clark
 // This file is licensed to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using Aydsko.iRacingData.Converters;
 
 namespace Aydsko.iRacingData.Results;
 
@@ -9,56 +9,18 @@ public class SeasonResults
 {
     [JsonPropertyName("results_list")]
     public SeasonRaceResult[] ResultsList { get; set; } = Array.Empty<SeasonRaceResult>();
+
     [JsonPropertyName("event_type")]
     public EventType EventType { get; set; }
+
     [JsonPropertyName("success")]
     public bool Success { get; set; }
+
     [JsonPropertyName("season_id")]
     public int SeasonId { get; set; }
+
     [JsonPropertyName("race_week_num")]
     public int RaceWeekNumber { get; set; }
-}
-
-public class SeasonRaceResult
-{
-    [JsonPropertyName("race_week_num")]
-    public int RaceWeekNum { get; set; }
-    [JsonPropertyName("event_type")]
-    public EventType EventType { get; set; }
-    [JsonPropertyName("event_type_name")]
-    public string? EventTypeName { get; set; }
-    [JsonPropertyName("start_time")]
-    public DateTime StartTime { get; set; }
-    [JsonPropertyName("session_id")]
-    public int SessionId { get; set; }
-    [JsonPropertyName("subsession_id")]
-    public int SubsessionId { get; set; }
-    [JsonPropertyName("official_session")]
-    public bool OfficialSession { get; set; }
-    [JsonPropertyName("event_strength_of_field")]
-    public int EventStrengthOfField { get; set; }
-    [JsonPropertyName("event_best_lap_time")]
-    public int EventBestLapTime { get; set; }
-    [JsonPropertyName("num_cautions")]
-    public int NumCautions { get; set; }
-    [JsonPropertyName("num_caution_laps")]
-    public int NumCautionLaps { get; set; }
-    [JsonPropertyName("num_lead_changes")]
-    public int NumLeadChanges { get; set; }
-    [JsonPropertyName("num_drivers")]
-    public int NumDrivers { get; set; }
-    [JsonPropertyName("track")]
-    public SeasonResultTrack Track { get; set; } = null!;
-}
-
-public class SeasonResultTrack
-{
-    [JsonPropertyName("track_id")]
-    public int TrackId { get; set; }
-    [JsonPropertyName("track_name")]
-    public string? TrackName { get; set; }
-    [JsonPropertyName("config_name")]
-    public string? ConfigName { get; set; }
 }
 
 [JsonSerializable(typeof(SeasonResults)), JsonSourceGenerationOptions(WriteIndented = true)]

--- a/src/Aydsko.iRacingData/Results/SubsessionChartLap.cs
+++ b/src/Aydsko.iRacingData/Results/SubsessionChartLap.cs
@@ -1,18 +1,31 @@
 ﻿// © 2022 Adrian Clark
 // This file is licensed to you under the MIT license.
 
-using System.Text.Json.Serialization;
-
 namespace Aydsko.iRacingData.Results;
 
 public class SubsessionChartLap : SubsessionLap
 {
     [JsonPropertyName("lap_position")]
     public int LapPosition { get; set; }
+
     [JsonPropertyName("interval")]
-    public int? Interval { get; set; }
+    public long? IntervalRaw { get; set; }
+
     [JsonPropertyName("interval_units")]
     public string IntervalUnits { get; set; } = null!;
+
+    // If there's one thing iRacing is consistent about, it is inconsistency!
+    // Normally an "interval" would be in ten-thousandth's of a second (i.e. 1 minute = "600000")
+    // Here they have the "interval" and "interval_units". In all the results I've harvested, the units are "ms" (obviously "milliseconds")
+    // So we can't use the normal "JsonConverter(typeof(TenThousandthSecondDurationConverter))" on the "interval" field.
+    [JsonIgnore]
+    public TimeSpan? Interval => (IntervalRaw, IntervalUnits) switch
+    {
+        (null, _) => null,
+        (_, "ms") => (TimeSpan?)TimeSpan.FromMilliseconds((double)IntervalRaw),
+        _ => throw new NotSupportedException($"Unsupported \"IntervalUnits\" value for CustomerId \"{CustomerId}\" on lap number \"{LapNumber}\"")
+    };
+
     [JsonPropertyName("fastest_lap")]
     public bool FastestLap { get; set; }
 }

--- a/src/Aydsko.iRacingData/Results/SubsessionLap.cs
+++ b/src/Aydsko.iRacingData/Results/SubsessionLap.cs
@@ -1,7 +1,7 @@
 ﻿// © 2022 Adrian Clark
 // This file is licensed to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using Aydsko.iRacingData.Converters;
 
 namespace Aydsko.iRacingData.Results;
 
@@ -9,36 +9,52 @@ public class SubsessionLap
 {
     [JsonPropertyName("group_id")]
     public int GroupId { get; set; }
+
     [JsonPropertyName("name")]
     public string Name { get; set; } = null!;
+
     [JsonPropertyName("cust_id")]
     public int CustomerId { get; set; }
+
     [JsonPropertyName("display_name")]
     public string DisplayName { get; set; } = null!;
+
     [JsonPropertyName("lap_number")]
     public int LapNumber { get; set; }
+
     [JsonPropertyName("flags")]
     public int Flags { get; set; }
+
     [JsonPropertyName("incident")]
     public bool Incident { get; set; }
+
     [JsonPropertyName("session_time")]
     public int SessionTime { get; set; }
+
     [JsonPropertyName("session_start_time")]
     public int? SessionStartTime { get; set; }
-    [JsonPropertyName("lap_time")]
-    public int LapTime { get; set; }
+
+    [JsonPropertyName("lap_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? LapTime { get; set; }
+
     [JsonPropertyName("team_fastest_lap")]
     public bool TeamFastestLap { get; set; }
+
     [JsonPropertyName("personal_best_lap")]
     public bool PersonalBestLap { get; set; }
+
     [JsonPropertyName("helmet")]
     public Helmet Helmet { get; set; } = null!;
+
     [JsonPropertyName("license_level")]
     public int LicenseLevel { get; set; }
+
     [JsonPropertyName("car_number")]
     public string CarNumber { get; set; } = null!;
+
     [JsonPropertyName("lap_events")]
     public string[] LapEvents { get; set; } = null!;
+
     [JsonPropertyName("ai")]
     public bool Ai { get; set; }
 }

--- a/src/Aydsko.iRacingData/Results/SubsessionLapHeader.cs
+++ b/src/Aydsko.iRacingData/Results/SubsessionLapHeader.cs
@@ -1,6 +1,8 @@
 ﻿// © 2022 Adrian Clark
 // This file is licensed to you under the MIT license.
 
+using Aydsko.iRacingData.Converters;
+
 namespace Aydsko.iRacingData.Results;
 
 public class SubsessionLapsHeader
@@ -14,23 +16,23 @@ public class SubsessionLapsHeader
     [JsonPropertyName("best_lap_num")]
     public int BestLapNum { get; set; }
 
-    [JsonPropertyName("best_lap_time")]
-    public int BestLapTime { get; set; }
+    [JsonPropertyName("best_lap_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? BestLapTime { get; set; }
 
     [JsonPropertyName("best_nlaps_num")]
     public int BestNlapsNum { get; set; }
 
-    [JsonPropertyName("best_nlaps_time")]
-    public int BestNlapsTime { get; set; }
+    [JsonPropertyName("best_nlaps_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? BestNlapsTime { get; set; }
 
     [JsonPropertyName("best_qual_lap_num")]
-    public int BestQualLapNum { get; set; }
+    public int BestQualifyingLapNum { get; set; }
 
-    [JsonPropertyName("best_qual_lap_time")]
-    public int BestQualLapTime { get; set; }
+    [JsonPropertyName("best_qual_lap_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? BestQualifyingLapTime { get; set; }
 
     [JsonPropertyName("best_qual_lap_at")]
-    public object? BestQualLapAt { get; set; }
+    public object? BestQualifyingLapAt { get; set; }
 
     [JsonPropertyName("chunk_info")]
     public ChunkInfo ChunkInfo { get; set; } = null!;

--- a/src/Aydsko.iRacingData/Stats/Race.cs
+++ b/src/Aydsko.iRacingData/Stats/Race.cs
@@ -1,7 +1,7 @@
 ﻿// © 2022 Adrian Clark
 // This file is licensed to you under the MIT license.
 
-using System.Text.Json.Serialization;
+using Aydsko.iRacingData.Converters;
 
 namespace Aydsko.iRacingData.Stats;
 
@@ -9,56 +9,82 @@ public class Race
 {
     [JsonPropertyName("season_id")]
     public int SeasonId { get; set; }
+
     [JsonPropertyName("series_id")]
     public int SeriesId { get; set; }
+
     [JsonPropertyName("series_name")]
     public string SeriesName { get; set; } = null!;
+
     [JsonPropertyName("car_id")]
     public int CarId { get; set; }
+
     [JsonPropertyName("car_class_id")]
     public int CarClassId { get; set; }
+
     [JsonPropertyName("livery")]
     public Livery Livery { get; set; } = null!;
+
     [JsonPropertyName("license_level")]
     public int LicenseLevel { get; set; }
+
     [JsonPropertyName("session_start_time")]
     public DateTime SessionStartTime { get; set; }
+
     [JsonPropertyName("winner_group_id")]
     public int WinnerGroupId { get; set; }
+
     [JsonPropertyName("winner_name")]
     public string WinnerName { get; set; } = null!;
+
     [JsonPropertyName("winner_helmet")]
     public Helmet WinnerHelmet { get; set; } = null!;
+
     [JsonPropertyName("winner_license_level")]
     public int WinnerLicenseLevel { get; set; }
+
     [JsonPropertyName("start_position")]
     public int StartPosition { get; set; }
+
     [JsonPropertyName("finish_position")]
     public int FinishPosition { get; set; }
-    [JsonPropertyName("qualifying_time")]
-    public int QualifyingTime { get; set; }
+
+    [JsonPropertyName("qualifying_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? QualifyingTime { get; set; }
+
     [JsonPropertyName("laps")]
     public int Laps { get; set; }
+
     [JsonPropertyName("laps_led")]
     public int LapsLed { get; set; }
+
     [JsonPropertyName("incidents")]
     public int Incidents { get; set; }
+
     [JsonPropertyName("club_points")]
     public int ClubPoints { get; set; }
+
     [JsonPropertyName("points")]
     public int Points { get; set; }
+
     [JsonPropertyName("strength_of_field")]
     public int StrengthOfField { get; set; }
+
     [JsonPropertyName("subsession_id")]
     public int SubsessionId { get; set; }
+
     [JsonPropertyName("old_sub_level")]
     public int OldSubLevel { get; set; }
+
     [JsonPropertyName("new_sub_level")]
     public int NewSubLevel { get; set; }
+
     [JsonPropertyName("oldi_rating")]
     public int OldiRating { get; set; }
+
     [JsonPropertyName("newi_rating")]
     public int NewiRating { get; set; }
+
     [JsonPropertyName("track")]
     public Track Track { get; set; } = null!;
 }

--- a/src/Aydsko.iRacingData/Stats/SeasonTimeTrialResult.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonTimeTrialResult.cs
@@ -1,6 +1,8 @@
 ﻿// © 2022 Adrian Clark
 // This file is licensed to you under the MIT license.
 
+using Aydsko.iRacingData.Converters;
+
 namespace Aydsko.iRacingData.Stats;
 
 public class SeasonTimeTrialResult
@@ -26,8 +28,8 @@ public class SeasonTimeTrialResult
     [JsonPropertyName("license")]
     public License License { get; set; } = null!;
 
-    [JsonPropertyName("best_nlaps_time")]
-    public int BestNlapsTime { get; set; }
+    [JsonPropertyName("best_nlaps_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? BestNlapsTime { get; set; }
 
     [JsonPropertyName("starts")]
     public int Starts { get; set; }

--- a/src/Aydsko.iRacingData/Tracks/Track.cs
+++ b/src/Aydsko.iRacingData/Tracks/Track.cs
@@ -1,8 +1,8 @@
 ﻿// © 2022 Adrian Clark
 // This file is licensed to you under the MIT license.
 
+using Aydsko.iRacingData.Converters;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 
 namespace Aydsko.iRacingData.Tracks;
 
@@ -10,96 +10,142 @@ public class Track
 {
     [JsonPropertyName("ai_enabled")]
     public bool AiEnabled { get; set; }
+
     [JsonPropertyName("award_exempt")]
     public bool AwardExempt { get; set; }
+
     [JsonPropertyName("category")]
     public string Category { get; set; } = default!;
+
     [JsonPropertyName("category_id")]
     public int CategoryId { get; set; }
+
     [JsonPropertyName("closes")]
     public string Closes { get; set; } = default!;
+
     [JsonPropertyName("config_name")]
     public string ConfigName { get; set; } = default!;
+
     [JsonPropertyName("corners_per_lap")]
     public int CornersPerLap { get; set; }
+
     [JsonPropertyName("created")]
     public DateTime Created { get; set; }
+
     [JsonPropertyName("free_with_subscription")]
     public bool FreeWithSubscription { get; set; }
+
     [JsonPropertyName("fully_lit")]
     public bool FullyLit { get; set; }
+
     [JsonPropertyName("grid_stalls")]
     public int GridStalls { get; set; }
+
     [JsonPropertyName("has_opt_path")]
     public bool HasOptPath { get; set; }
+
     [JsonPropertyName("has_short_parade_lap")]
     public bool HasShortParadeLap { get; set; }
+
     [JsonPropertyName("has_svg_map")]
     public bool HasSvgMap { get; set; }
+
     [JsonPropertyName("is_dirt")]
     public bool IsDirt { get; set; }
+
     [JsonPropertyName("is_oval")]
     public bool IsOval { get; set; }
+
     [JsonPropertyName("lap_scoring")]
     public int LapScoring { get; set; }
+
     [JsonPropertyName("latitude")]
-    public float Latitude { get; set; }
+    public decimal Latitude { get; set; }
+
     [JsonPropertyName("location")]
     public string Location { get; set; } = default!;
+
     [JsonPropertyName("longitude")]
-    public float Longitude { get; set; }
+    public decimal Longitude { get; set; }
+
     [JsonPropertyName("max_cars")]
     public int MaxCars { get; set; }
+
     [JsonPropertyName("night_lighting")]
     public bool NightLighting { get; set; }
-    [JsonPropertyName("nominal_lap_time")]
-    public float NominalLapTime { get; set; }
+
+    [JsonPropertyName("nominal_lap_time"), JsonConverter(typeof(TenThousandthSecondDurationConverter))]
+    public TimeSpan? NominalLapTime { get; set; }
+
     [JsonPropertyName("number_pitstalls")]
     public int NumberPitstalls { get; set; }
+
     [JsonPropertyName("opens")]
     public string Opens { get; set; } = default!;
+
     [JsonPropertyName("package_id")]
     public int PackageId { get; set; }
+
     [JsonPropertyName("pit_road_speed_limit")]
     public int PitRoadSpeedLimit { get; set; }
+
     [JsonPropertyName("price")]
-    public float Price { get; set; }
+    public decimal Price { get; set; }
+
     [JsonPropertyName("priority")]
     public int Priority { get; set; }
+
     [JsonPropertyName("purchasable")]
     public bool Purchasable { get; set; }
+
     [JsonPropertyName("qualify_laps")]
     public int QualifyLaps { get; set; }
+
     [JsonPropertyName("restart_on_left")]
     public bool RestartOnLeft { get; set; }
+
     [JsonPropertyName("retired")]
     public bool Retired { get; set; }
+
     [JsonPropertyName("search_filters")]
     public string SearchFilters { get; set; } = default!;
+
     [JsonPropertyName("site_url"), SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = "Strings are easier to deal with.")]
     public string SiteUrl { get; set; } = default!;
+
     [JsonPropertyName("sku")]
     public int Sku { get; set; }
+
     [JsonPropertyName("solo_laps")]
     public int SoloLaps { get; set; }
+
     [JsonPropertyName("start_on_left")]
     public bool StartOnLeft { get; set; }
+
     [JsonPropertyName("supports_grip_compound")]
     public bool SupportsGripCompound { get; set; }
+
     [JsonPropertyName("tech_track")]
     public bool TechTrack { get; set; }
+
     [JsonPropertyName("time_zone")]
     public string TimeZone { get; set; } = default!;
+
     [JsonPropertyName("track_config_length")]
     public float TrackConfigLength { get; set; }
+
     [JsonPropertyName("track_dirpath")]
     public string TrackDirpath { get; set; } = default!;
+
     [JsonPropertyName("track_id")]
     public int TrackId { get; set; }
+
     [JsonPropertyName("track_name")]
     public string TrackName { get; set; } = default!;
+
     [JsonPropertyName("track_types")]
     public TrackTypes[] TrackTypes { get; set; } = Array.Empty<TrackTypes>();
+
     [JsonPropertyName("banking")]
     public string Banking { get; set; } = default!;
 }


### PR DESCRIPTION
The raw iRacing API results use a number type which carries duration values to the ten-thousandth of a second. So, for example, a lap which was displayed in the iRacing results page as 1:23.456 would be returned as 834560.

This change implements a converter for that and applies this "TenThousandthSecondDurationConverter" to all duration-like fields using the  so the values can be expressed as "TimeSpan" instead of just a "long" value.

Fixes: #47