### PR TITLE
Revert Usage of Parameter Null Checking

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -135,6 +135,7 @@ csharp_style_prefer_not_pattern = true:suggestion
 dotnet_diagnostic.CA1812.severity = silent
 csharp_style_prefer_method_group_conversion = true:silent
 insert_final_newline = true
+csharp_style_prefer_parameter_null_checking = false:suggestion
 
 [*.{cs,vb}]
 dotnet_style_operator_placement_when_wrapping = beginning_of_line

--- a/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
@@ -340,7 +340,7 @@ public class CapturedResponseValidationTests : MockedHttpTestBase
     {
         await MessageHandler.QueueResponsesAsync(nameof(GetMemberDivisionSuccessfulAsync)).ConfigureAwait(false);
 
-        var memberDivisionResponse = await sut.GetMemberDivisionAsync(1234, EventType.Race, CancellationToken.None);
+        var memberDivisionResponse = await sut.GetMemberDivisionAsync(1234, EventType.Race, CancellationToken.None).ConfigureAwait(false);
 
         Assert.That(memberDivisionResponse, Is.Not.Null);
         Assert.That(memberDivisionResponse.Data, Is.Not.Null);

--- a/src/Aydsko.iRacingData.UnitTests/Converters/JsonConverterTestExtensions.cs
+++ b/src/Aydsko.iRacingData.UnitTests/Converters/JsonConverterTestExtensions.cs
@@ -10,25 +10,23 @@ public static class JsonConverterTestExtensions
 {
     private const string InvalidJsonObjectInputFormatMessage = "Expected input to be in the format \"{\"value\":\"(INPUT TO BE TESTED)\"}\" or \"{\"value\":(INPUT TO BE TESTED)}\" where (INPUT TO BE TESTED) was replaced with the value to be tested.";
 
-#pragma warning disable CA1062 // Validate arguments of public methods - check done with "!!" operator
-
-    public static IEnumerable<TestCaseData> ToReadValueTestCases<T>(this IEnumerable<(byte[] JsonBytes, T Value, string Name)> examples!!)
+    public static IEnumerable<TestCaseData> ToReadValueTestCases<T>(this IEnumerable<(byte[] JsonBytes, T Value, string Name)> examples)
     {
-        foreach (var (jsonValueBytes, timeValue, name) in examples)
+        foreach (var (jsonValueBytes, timeValue, name) in examples ?? Enumerable.Empty<(byte[] JsonBytes, T Value, string Name)>())
         {
             yield return new TestCaseData(new object[] { jsonValueBytes }).Returns(timeValue).SetName("Read Value: " + name);
         }
     }
 
-    public static IEnumerable<TestCaseData> ToWriteValueTestCases<T>(this IEnumerable<(byte[] JsonBytes, T Value, string Name)> examples!!)
+    public static IEnumerable<TestCaseData> ToWriteValueTestCases<T>(this IEnumerable<(byte[] JsonBytes, T Value, string Name)> examples)
     {
-        foreach (var (jsonValueBytes, timeValue, name) in examples)
+        foreach (var (jsonValueBytes, timeValue, name) in examples ?? Enumerable.Empty<(byte[] JsonBytes, T Value, string Name)>())
         {
             yield return new TestCaseData(timeValue).Returns(jsonValueBytes).SetName("Write Value: " + name);
         }
     }
 
-    public static Utf8JsonReader ToUtf8JsonReaderForTest(this byte[] input!!)
+    public static Utf8JsonReader ToUtf8JsonReaderForTest(this byte[] input)
     {
         var reader = new Utf8JsonReader(input.AsSpan());
 
@@ -50,8 +48,13 @@ public static class JsonConverterTestExtensions
         return reader;
     }
 
-    public static byte[] WriteUsingConverter<T>(this T input, JsonConverter<T> converter!!)
+    public static byte[] WriteUsingConverter<T>(this T input, JsonConverter<T> converter)
     {
+        if (converter is null)
+        {
+            throw new ArgumentNullException(nameof(converter));
+        }
+
         using var outputStream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(outputStream))
         {
@@ -64,6 +67,4 @@ public static class JsonConverterTestExtensions
 
         return outputStream.ToArray();
     }
-
-#pragma warning restore CA1062 // Validate arguments of public methods
 }

--- a/src/Aydsko.iRacingData.UnitTests/MockedHttpMessageHandler.cs
+++ b/src/Aydsko.iRacingData.UnitTests/MockedHttpMessageHandler.cs
@@ -22,9 +22,13 @@ public class MockedHttpMessageHandler : HttpMessageHandler
         this.cookieContainer = cookieContainer;
     }
 
-    [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "<Pending>")]
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request!!, CancellationToken cancellationToken)
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
         cancellationToken.ThrowIfCancellationRequested();
 
         Requests.Enqueue(request);

--- a/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
+++ b/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
@@ -27,57 +27,23 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute">
       <_Parameter1>Style</_Parameter1>
       <_Parameter2>IDE1006:Naming Styles</_Parameter2>
-      <_Parameter3>Justification = "&lt;The company name which supplies this data API uses the lowercase i prefix so this is a proper name.&gt;"</_Parameter3>
+      <_Parameter3>Justification = "The company name which supplies this data API uses the lowercase i prefix so this is a proper name."</_Parameter3>
       <_Parameter3_IsLiteral>true</_Parameter3_IsLiteral>
-      <_Parameter4>Scope = "type"</_Parameter4>
+      <_Parameter4>Scope = "module"</_Parameter4>
       <_Parameter4_IsLiteral>true</_Parameter4_IsLiteral>
-      <_Parameter5>Target = "~T:Aydsko.iRacingData.iRacingDataClientException"</_Parameter5>
-      <_Parameter5_IsLiteral>true</_Parameter5_IsLiteral>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute">
-      <_Parameter1>Style</_Parameter1>
-      <_Parameter2>IDE1006:Naming Styles</_Parameter2>
-      <_Parameter3>Justification = "&lt;The company name which supplies this data API uses the lowercase i prefix so this is a proper name.&gt;"</_Parameter3>
-      <_Parameter3_IsLiteral>true</_Parameter3_IsLiteral>
-      <_Parameter4>Scope = "type"</_Parameter4>
-      <_Parameter4_IsLiteral>true</_Parameter4_IsLiteral>
-      <_Parameter5>Target = "~T:Aydsko.iRacingData.iRacingInMaintenancePeriodException"</_Parameter5>
-      <_Parameter5_IsLiteral>true</_Parameter5_IsLiteral>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute">
-      <_Parameter1>Style</_Parameter1>
-      <_Parameter2>IDE1006:Naming Styles</_Parameter2>
-      <_Parameter3>Justification = "&lt;The company name which supplies this data API uses the lowercase i prefix so this is a proper name.&gt;"</_Parameter3>
-      <_Parameter3_IsLiteral>true</_Parameter3_IsLiteral>
-      <_Parameter4>Scope = "type"</_Parameter4>
-      <_Parameter4_IsLiteral>true</_Parameter4_IsLiteral>
-      <_Parameter5>Target = "~T:Aydsko.iRacingData.iRacingClientOptionsValueMissingException"</_Parameter5>
-      <_Parameter5_IsLiteral>true</_Parameter5_IsLiteral>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute">
-      <_Parameter1>Style</_Parameter1>
-      <_Parameter2>IDE1006:Naming Styles</_Parameter2>
-      <_Parameter3>Justification = "&lt;The company name which supplies this data API uses the lowercase i prefix so this is a proper name.&gt;"</_Parameter3>
-      <_Parameter3_IsLiteral>true</_Parameter3_IsLiteral>
-      <_Parameter4>Scope = "type"</_Parameter4>
-      <_Parameter4_IsLiteral>true</_Parameter4_IsLiteral>
-      <_Parameter5>Target = "~T:Aydsko.iRacingData.iRacingForbiddenResponseException"</_Parameter5>
-      <_Parameter5_IsLiteral>true</_Parameter5_IsLiteral>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute">
-      <_Parameter1>Style</_Parameter1>
-      <_Parameter2>IDE1006:Naming Styles</_Parameter2>
-      <_Parameter3>Justification = "&lt;The company name which supplies this data API uses the lowercase i prefix so this is a proper name.&gt;"</_Parameter3>
-      <_Parameter3_IsLiteral>true</_Parameter3_IsLiteral>
-      <_Parameter4>Scope = "type"</_Parameter4>
-      <_Parameter4_IsLiteral>true</_Parameter4_IsLiteral>
-      <_Parameter5>Target = "~T:Aydsko.iRacingData.iRacingDataClientOptions"</_Parameter5>
-      <_Parameter5_IsLiteral>true</_Parameter5_IsLiteral>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute">
       <_Parameter1>Performance</_Parameter1>
       <_Parameter2>CA1819:Properties should not return arrays</_Parameter2>
-      <_Parameter3>Justification = "&lt;Usage is almost entirely data transfer objects (DTOs) which are one of the exemptions for this rule.&gt;"</_Parameter3>
+      <_Parameter3>Justification = "Usage is almost entirely data transfer objects (DTOs) which are one of the exemptions for this rule."</_Parameter3>
+      <_Parameter3_IsLiteral>true</_Parameter3_IsLiteral>
+      <_Parameter4>Scope = "module"</_Parameter4>
+      <_Parameter4_IsLiteral>true</_Parameter4_IsLiteral>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute">
+      <_Parameter1>Design</_Parameter1>
+      <_Parameter2>CA1056:URI-like properties should not be strings</_Parameter2>
+      <_Parameter3>Justification = "Processing is simpler both for deserialization and combining for use."</_Parameter3>
       <_Parameter3_IsLiteral>true</_Parameter3_IsLiteral>
       <_Parameter4>Scope = "module"</_Parameter4>
       <_Parameter4_IsLiteral>true</_Parameter4_IsLiteral>

--- a/src/Aydsko.iRacingData/Converters/DateTimeConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/DateTimeConverter.cs
@@ -24,11 +24,15 @@ public class DateTimeConverter : JsonConverter<DateTime>
         return dateValue;
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Check is being done, diagnostic requires an update.")]
-    public override void Write(Utf8JsonWriter writer!!,
+    public override void Write(Utf8JsonWriter writer,
                                DateTime value,
                                JsonSerializerOptions options)
     {
+        if (writer is null)
+        {
+            throw new ArgumentNullException(nameof(writer));
+        }
+
         writer.WriteStringValue(value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
     }
 }

--- a/src/Aydsko.iRacingData/Converters/TenThousandthSecondDurationConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/TenThousandthSecondDurationConverter.cs
@@ -30,10 +30,15 @@ public class TenThousandthSecondDurationConverter : JsonConverter<TimeSpan?>
         return TimeSpan.FromSeconds(value.Value / 10000D); // iRacing reports to the ten-thousandth & this is the easiest way to parse out.
     }
 
-    public override void Write(Utf8JsonWriter writer!!,
+    public override void Write(Utf8JsonWriter writer,
                                TimeSpan? value,
                                JsonSerializerOptions options)
     {
+        if (writer is null)
+        {
+            throw new ArgumentNullException(nameof(writer));
+        }
+
         if (value is null)
         {
             writer.WriteNullValue();

--- a/src/Aydsko.iRacingData/DataClient.cs
+++ b/src/Aydsko.iRacingData/DataClient.cs
@@ -248,7 +248,7 @@ internal class DataClient : IDataClient
             var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
             if (!chunkResponse.IsSuccessStatusCode)
             {
-                logger.LogError("Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount}", index, data.ChunkInfo.NumChunks);
+                logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                 continue;
             }
 
@@ -289,7 +289,7 @@ internal class DataClient : IDataClient
             var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
             if (!chunkResponse.IsSuccessStatusCode)
             {
-                logger.LogError("Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount}", index, data.ChunkInfo.NumChunks);
+                logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                 continue;
             }
 
@@ -331,7 +331,7 @@ internal class DataClient : IDataClient
             var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
             if (!chunkResponse.IsSuccessStatusCode)
             {
-                logger.LogError("Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount}", index, data.ChunkInfo.NumChunks);
+                logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                 continue;
             }
 
@@ -373,7 +373,7 @@ internal class DataClient : IDataClient
             var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
             if (!chunkResponse.IsSuccessStatusCode)
             {
-                logger.LogError("Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount}", index, data.ChunkInfo.NumChunks);
+                logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                 continue;
             }
 
@@ -444,7 +444,7 @@ internal class DataClient : IDataClient
             var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
             if (!chunkResponse.IsSuccessStatusCode)
             {
-                logger.LogError("Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount}", index, data.ChunkInfo.NumChunks);
+                logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                 continue;
             }
 
@@ -486,7 +486,7 @@ internal class DataClient : IDataClient
             var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
             if (!chunkResponse.IsSuccessStatusCode)
             {
-                logger.LogError("Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount}", index, data.ChunkInfo.NumChunks);
+                logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                 continue;
             }
 
@@ -528,7 +528,7 @@ internal class DataClient : IDataClient
             var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
             if (!chunkResponse.IsSuccessStatusCode)
             {
-                logger.LogError("Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount}", index, data.ChunkInfo.NumChunks);
+                logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                 continue;
             }
 
@@ -570,7 +570,7 @@ internal class DataClient : IDataClient
             var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
             if (!chunkResponse.IsSuccessStatusCode)
             {
-                logger.LogError("Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount}", index, data.ChunkInfo.NumChunks);
+                logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                 continue;
             }
 
@@ -612,7 +612,7 @@ internal class DataClient : IDataClient
             var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
             if (!chunkResponse.IsSuccessStatusCode)
             {
-                logger.LogError("Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount}", index, data.ChunkInfo.NumChunks);
+                logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                 continue;
             }
 

--- a/src/Aydsko.iRacingData/LoggingExtensions.cs
+++ b/src/Aydsko.iRacingData/LoggingExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// © 2022 Adrian Clark
 // This file is licensed to you under the MIT license.
 
+using System.Net;
+
 namespace Aydsko.iRacingData;
 
 public static class LoggingExtensions
@@ -9,6 +11,7 @@ public static class LoggingExtensions
     private const int EventIdRateLimitsUpdated = 2;
     private const int EventIdErrorResponseUnknownTrace = 3;
     private const int EventIdErrorResponseTrace = 4;
+    private const int EventIdFailedToRetrieveChunkError = 5;
 
     private static readonly Action<ILogger, string, Exception?> loginSuccessful = LoggerMessage.Define<string>(LogLevel.Information,
                                                                                                                new EventId(EventIdLoginSuccessful, nameof(LoginSuccessful)),
@@ -22,6 +25,9 @@ public static class LoggingExtensions
     private static readonly Action<ILogger, string?, Exception?> errorResponse = LoggerMessage.Define<string?>(LogLevel.Trace,
                                                                                                                new EventId(EventIdErrorResponseTrace, nameof(ErrorResponse)),
                                                                                                                "Error response from iRacing API: {ErrorDescription}");
+    private static readonly Action<ILogger, int?, int?, HttpStatusCode?, string?, Exception?> failedToRetrieveChunkError = LoggerMessage.Define<int?, int?, HttpStatusCode?, string?>(LogLevel.Error,
+                                                                                                                                                                                      new EventId(EventIdFailedToRetrieveChunkError, nameof(FailedToRetrieveChunkError)),
+                                                                                                                                                                                      "Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount} due to status code {HttpStatusCode} reason {HttpStatusReasonPhrase}");
 
     public static void LoginSuccessful(this ILogger logger, string userEmail)
     {
@@ -41,5 +47,10 @@ public static class LoggingExtensions
     public static void ErrorResponse(this ILogger logger, string? errorDescription, Exception exception)
     {
         errorResponse(logger, errorDescription, exception);
+    }
+
+    public static void FailedToRetrieveChunkError(this ILogger logger, int? chunkIndex, int? chunkTotalCount, HttpStatusCode? httpStatusCode, string? reasonPhrase)
+    {
+        failedToRetrieveChunkError(logger, chunkIndex, chunkTotalCount, httpStatusCode, reasonPhrase, null);
     }
 }

--- a/src/Aydsko.iRacingData/ServicesExtensions.cs
+++ b/src/Aydsko.iRacingData/ServicesExtensions.cs
@@ -10,16 +10,31 @@ namespace Aydsko.iRacingData;
 
 public static class ServicesExtensions
 {
-    public static IServiceCollection AddIRacingDataApi(this IServiceCollection services!!, Action<iRacingDataClientOptions> configureOptions!!)
+    public static IServiceCollection AddIRacingDataApi(this IServiceCollection services, Action<iRacingDataClientOptions> configureOptions)
     {
-#pragma warning disable CA1062 // Validate arguments of public methods
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (configureOptions is null)
+        {
+            throw new ArgumentNullException(nameof(configureOptions));
+        }
+
         services.AddIRacingDataApiInternal(configureOptions);
-#pragma warning restore CA1062 // Validate arguments of public methods
         return services;
     }
 
-    static internal IHttpClientBuilder AddIRacingDataApiInternal(this IServiceCollection services!!, Action<iRacingDataClientOptions> configureOptions!!)
+    static internal IHttpClientBuilder AddIRacingDataApiInternal(this IServiceCollection services, Action<iRacingDataClientOptions> configureOptions)
     {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        configureOptions ??= opt => { };
+
         services.TryAddSingleton(new CookieContainer());
 
         var options = new iRacingDataClientOptions();
@@ -53,8 +68,13 @@ public static class ServicesExtensions
         return httpClientBuilder;
     }
 
-    private static string CreateUserAgentValue(iRacingDataClientOptions options!!)
+    private static string CreateUserAgentValue(iRacingDataClientOptions options)
     {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
         if (options.UserAgentProductName is not string userAgentProductName)
         {
             userAgentProductName = Assembly.GetEntryAssembly()?.GetName().Name ?? "Unknown";
@@ -65,7 +85,7 @@ public static class ServicesExtensions
             userAgentProductVersion = Assembly.GetEntryAssembly()?.GetName().Version ?? new Version(0, 0);
         }
 
-        var dataClientVersion = typeof(DataClient).Assembly.GetName().Version.ToString(3);
+        var dataClientVersion = typeof(DataClient).Assembly.GetName()?.Version?.ToString(3) ?? "0.0";
         var userAgentValue = $"{userAgentProductName}/{userAgentProductVersion} Aydsko.iRacingDataClient/{dataClientVersion}";
         return userAgentValue;
     }

--- a/src/Aydsko.iRacingData/iRacingClientOptionsValueMissingException.cs
+++ b/src/Aydsko.iRacingData/iRacingClientOptionsValueMissingException.cs
@@ -8,7 +8,7 @@ namespace Aydsko.iRacingData;
 [Serializable]
 public class iRacingClientOptionsValueMissingException : iRacingDataClientException
 {
-    public static iRacingClientOptionsValueMissingException Create(string propertyName!!)
+    public static iRacingClientOptionsValueMissingException Create(string propertyName)
     {
         return new($"Required iRacingDataClientOptions value \"{propertyName}\" is null or whitespace.");
     }


### PR DESCRIPTION
The C# 11 preview feature "Parameter Null Checking" which would throw an "ArgumentNullException" if a parameter marked with the "!!" operator was null.

This feature is being removed from C#11:
https://devblogs.microsoft.com/dotnet/csharp-11-preview-updates/#remove-parameter-null-checking-from-c-11