### PR TITLE
Use "DateTimeOffset" for Instant Values

### DIFF
--- a/src/Aydsko.iRacingData/Cars/CarInfo.cs
+++ b/src/Aydsko.iRacingData/Cars/CarInfo.cs
@@ -9,66 +9,97 @@ public class CarInfo
 {
     [JsonPropertyName("ai_enabled")]
     public bool AiEnabled { get; set; }
+
     [JsonPropertyName("allow_number_colors")]
     public bool AllowNumberColors { get; set; }
+
     [JsonPropertyName("allow_number_font")]
     public bool AllowNumberFont { get; set; }
+
     [JsonPropertyName("allow_sponsor1")]
     public bool AllowSponsor1 { get; set; }
+
     [JsonPropertyName("allow_sponsor2")]
     public bool AllowSponsor2 { get; set; }
+
     [JsonPropertyName("allow_wheel_color")]
     public bool AllowWheelColor { get; set; }
+
     [JsonPropertyName("award_exempt")]
     public bool AwardExempt { get; set; }
+
     [JsonPropertyName("car_dirpath")]
     public string CarDirectoryPath { get; set; } = default!;
+
     [JsonPropertyName("car_id")]
     public int CarId { get; set; }
+
     [JsonPropertyName("car_name")]
     public string CarName { get; set; } = default!;
+
     [JsonPropertyName("car_name_abbreviated")]
     public string CarNameAbbreviated { get; set; } = default!;
+
     [JsonPropertyName("car_types")]
     public CarTypes[] CarTypes { get; set; } = Array.Empty<CarTypes>();
+
     [JsonPropertyName("car_weight")]
     public int CarWeight { get; set; }
+
     [JsonPropertyName("categories")]
     public string[] Categories { get; set; } = Array.Empty<string>();
+
     [JsonPropertyName("created")]
-    public DateTime Created { get; set; }
+    public DateTimeOffset Created { get; set; }
+
     [JsonPropertyName("free_with_subscription")]
     public bool FreeWithSubscription { get; set; }
+
     [JsonPropertyName("has_headlights")]
     public bool HasHeadlights { get; set; }
+
     [JsonPropertyName("has_multiple_dry_tire_types")]
     public bool HasMultipleDryTireTypes { get; set; }
+
     [JsonPropertyName("hp")]
     public int Hp { get; set; }
+
     [JsonPropertyName("max_power_adjust_pct")]
     public int MaxPowerAdjustPct { get; set; }
+
     [JsonPropertyName("max_weight_penalty_kg")]
     public int MaxWeightPenaltyKg { get; set; }
+
     [JsonPropertyName("min_power_adjust_pct")]
     public int MinPowerAdjustPct { get; set; }
+
     [JsonPropertyName("package_id")]
     public int PackageId { get; set; }
+
     [JsonPropertyName("patterns")]
     public int Patterns { get; set; }
+
     [JsonPropertyName("price")]
     public float Price { get; set; }
+
     [JsonPropertyName("retired")]
     public bool Retired { get; set; }
+
     [JsonPropertyName("search_filters")]
     public string SearchFilters { get; set; } = default!;
+
     [JsonPropertyName("sku")]
     public int Sku { get; set; }
+
     [JsonPropertyName("paint_rules")]
     public PaintRules PaintRules { get; set; } = default!;
+
     [JsonPropertyName("car_make")]
     public string CarMake { get; set; } = default!;
+
     [JsonPropertyName("car_model")]
     public string CarModel { get; set; } = default!;
+
     [JsonPropertyName("site_url"), JsonConverter(typeof(UriConverter))]
     public Uri? SiteUrl { get; set; } = default!;
 }

--- a/src/Aydsko.iRacingData/Common/DataResponse.cs
+++ b/src/Aydsko.iRacingData/Common/DataResponse.cs
@@ -7,10 +7,13 @@ public class DataResponse<TData>
 {
     /// <summary>The current total rate limit.</summary>
     public int? TotalRateLimit { get; set; }
+
     /// <summary>Amount of rate limit remaining.</summary>
     public int? RateLimitRemaining { get; set; }
+
     /// <summary>Instant at which the rate limit will be reset.</summary>
     public DateTimeOffset? RateLimitReset { get; set; }
+
     /// <summary>Data returned from the API call.</summary>
     public TData Data { get; set; } = default!;
 }

--- a/src/Aydsko.iRacingData/Leagues/League.cs
+++ b/src/Aydsko.iRacingData/Leagues/League.cs
@@ -1,46 +1,61 @@
 ﻿// © 2022 Adrian Clark
 // This file is licensed to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Aydsko.iRacingData.Leagues;
 
 public class League
 {
     [JsonPropertyName("league_id")]
     public int LeagueId { get; set; }
+
     [JsonPropertyName("owner_id")]
     public int OwnerId { get; set; }
+
     [JsonPropertyName("league_name")]
     public string LeagueName { get; set; } = null!;
+
     [JsonPropertyName("created")]
-    public DateTime Created { get; set; }
+    public DateTimeOffset Created { get; set; }
+
     [JsonPropertyName("hidden")]
     public bool Hidden { get; set; }
+
     [JsonPropertyName("message")]
     public string Message { get; set; } = null!;
+
     [JsonPropertyName("about")]
     public string About { get; set; } = null!;
-    [JsonPropertyName("url"), SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = "Strings are easier to deal with.")]
+
+    [JsonPropertyName("url")]
     public string Url { get; set; } = null!;
+
     [JsonPropertyName("recruiting")]
     public bool Recruiting { get; set; }
+
     [JsonPropertyName("private_wall")]
     public bool PrivateWall { get; set; }
+
     [JsonPropertyName("private_roster")]
     public bool PrivateRoster { get; set; }
+
     [JsonPropertyName("private_schedule")]
     public bool PrivateSchedule { get; set; }
+
     [JsonPropertyName("private_results")]
     public bool PrivateResults { get; set; }
+
     [JsonPropertyName("roster_count")]
     public int RosterCount { get; set; }
+
     [JsonPropertyName("owner")]
     public Owner Owner { get; set; } = null!;
+
     [JsonPropertyName("image")]
     public Image Image { get; set; } = null!;
+
     [JsonPropertyName("tags")]
     public Tags Tags { get; set; } = null!;
+
     [JsonPropertyName("roster")]
     public RosterMember[] Roster { get; set; } = null!;
 }

--- a/src/Aydsko.iRacingData/Leagues/RosterMember.cs
+++ b/src/Aydsko.iRacingData/Leagues/RosterMember.cs
@@ -7,22 +7,31 @@ public class RosterMember
 {
     [JsonPropertyName("cust_id")]
     public int CustomerId { get; set; }
+
     [JsonPropertyName("display_name")]
     public string DisplayName { get; set; } = null!;
+
     [JsonPropertyName("helmet")]
     public Helmet Helmet { get; set; } = null!;
+
     [JsonPropertyName("owner")]
     public bool Owner { get; set; }
+
     [JsonPropertyName("admin")]
     public bool Admin { get; set; }
+
     [JsonPropertyName("league_mail_opt_out")]
     public bool LeagueMailOptOut { get; set; }
+
     [JsonPropertyName("league_pm_opt_out")]
     public bool LeaguePrivateMessageOptOut { get; set; }
+
     [JsonPropertyName("league_member_since")]
-    public DateTime LeagueMemberSince { get; set; }
+    public DateTimeOffset LeagueMemberSince { get; set; }
+
     [JsonPropertyName("car_number")]
     public string? CarNumber { get; set; }
+
     [JsonPropertyName("nick_name")]
     public string? NickName { get; set; }
 }

--- a/src/Aydsko.iRacingData/Member/DriverInfo.cs
+++ b/src/Aydsko.iRacingData/Member/DriverInfo.cs
@@ -7,20 +7,28 @@ public class DriverInfo
 {
     [JsonPropertyName("cust_id")]
     public int CustomerId { get; set; }
+
     [JsonPropertyName("display_name")]
     public string DisplayName { get; set; } = default!;
+
     [JsonPropertyName("helmet")]
     public Helmet Helmet { get; set; } = default!;
+
     [JsonPropertyName("last_login")]
-    public DateTime LastLogin { get; set; }
+    public DateTimeOffset LastLogin { get; set; }
+
     [JsonPropertyName("member_since")]
     public string MemberSince { get; set; } = default!;
+
     [JsonPropertyName("club_id")]
     public int ClubId { get; set; }
+
     [JsonPropertyName("club_name")]
     public string ClubName { get; set; } = default!;
+
     [JsonPropertyName("ai")]
     public bool AI { get; set; }
+
     [JsonPropertyName("licenses")]
     public LicenseInfo[]? Licenses { get; set; }
 }

--- a/src/Aydsko.iRacingData/Member/MemberInfo.cs
+++ b/src/Aydsko.iRacingData/Member/MemberInfo.cs
@@ -7,78 +7,115 @@ public class MemberInfo
 {
     [JsonPropertyName("cust_id")]
     public int CustomerId { get; set; }
+
     [JsonPropertyName("email")]
     public string Email { get; set; } = default!;
+
     [JsonPropertyName("username")]
     public string Username { get; set; } = default!;
+
     [JsonPropertyName("display_name")]
     public string DisplayName { get; set; } = default!;
+
     [JsonPropertyName("first_name")]
     public string FirstName { get; set; } = default!;
+
     [JsonPropertyName("last_name")]
     public string LastName { get; set; } = default!;
+
     [JsonPropertyName("on_car_name")]
     public string OnCarName { get; set; } = default!;
+
     [JsonPropertyName("member_since")]
     public string MemberSince { get; set; } = default!;
+
     [JsonPropertyName("last_test_track")]
     public int LastTestTrack { get; set; }
+
     [JsonPropertyName("last_test_car")]
     public int LastTestCar { get; set; }
+
     [JsonPropertyName("last_season")]
     public int LastSeason { get; set; }
+
     [JsonPropertyName("flags")]
     public int Flags { get; set; }
+
     [JsonPropertyName("club_id")]
     public int ClubId { get; set; }
+
     [JsonPropertyName("club_name")]
     public string ClubName { get; set; } = default!;
+
     [JsonPropertyName("connection_type")]
     public string ConnectionType { get; set; } = default!;
+
     [JsonPropertyName("download_server")]
     public string DownloadServer { get; set; } = default!;
+
     [JsonPropertyName("last_login")]
-    public DateTime LastLogin { get; set; }
+    public DateTimeOffset LastLogin { get; set; }
+
     [JsonPropertyName("read_comp_rules")]
-    public DateTime ReadCompRules { get; set; }
+    public DateTimeOffset ReadCompRules { get; set; }
+
     [JsonPropertyName("account")]
     public Account Account { get; set; } = default!;
+
     [JsonPropertyName("helmet")]
     public Helmet Helmet { get; set; } = default!;
+
     [JsonPropertyName("suit")]
     public Suit Suit { get; set; } = default!;
+
     [JsonPropertyName("licenses")]
     public Licenses Licenses { get; set; } = default!;
+
     [JsonPropertyName("car_packages")]
     public ContentPackage[] CarPackages { get; set; } = default!;
+
     [JsonPropertyName("track_packages")]
     public ContentPackage[] TrackPackages { get; set; } = default!;
+
     [JsonPropertyName("other_owned_packages")]
     public int[] OtherOwnedPackages { get; set; } = default!;
+
     [JsonPropertyName("dev")]
     public bool Dev { get; set; }
+
     [JsonPropertyName("alpha_tester")]
     public bool AlphaTester { get; set; }
+
     [JsonPropertyName("broadcaster")]
     public bool Broadcaster { get; set; }
+
     [JsonPropertyName("has_read_comp_rules")]
     public bool HasReadCompRules { get; set; }
+
     [JsonPropertyName("flags_hex")]
     public string FlagsHex { get; set; } = default!;
+
     [JsonPropertyName("hundred_pct_club")]
     public bool HundredPercentClub { get; set; }
+
     [JsonPropertyName("twenty_pct_discount")]
     public bool TwentyPercentDiscount { get; set; }
+
     [JsonPropertyName("race_official")]
     public bool RaceOfficial { get; set; }
+
     [JsonPropertyName("ai")]
     public bool AI { get; set; }
+
     [JsonPropertyName("read_tc")]
-    public DateTime ReadTc { get; set; }
+    public DateTimeOffset ReadTc { get; set; }
+
     [JsonPropertyName("read_pp")]
-    public DateTime ReadPp { get; set; }
+    public DateTimeOffset ReadPp { get; set; }
+
     [JsonPropertyName("has_read_tc")]
     public bool HasReadTC { get; set; }
+
     [JsonPropertyName("has_read_pp")]
     public bool HasReadPp { get; set; }
 }

--- a/src/Aydsko.iRacingData/Results/Result.cs
+++ b/src/Aydsko.iRacingData/Results/Result.cs
@@ -51,7 +51,7 @@ public class Result
     public TimeSpan? BestNlapsTime { get; set; }
 
     [JsonPropertyName("best_qual_lap_at")]
-    public DateTime BestQualifyingLapAt { get; set; }
+    public DateTimeOffset? BestQualifyingLapAt { get; set; }
 
     [JsonPropertyName("best_qual_lap_num")]
     public int BestQualifyingLapNum { get; set; }

--- a/src/Aydsko.iRacingData/Results/SeasonRaceResult.cs
+++ b/src/Aydsko.iRacingData/Results/SeasonRaceResult.cs
@@ -17,7 +17,7 @@ public class SeasonRaceResult
     public string? EventTypeName { get; set; }
 
     [JsonPropertyName("start_time")]
-    public DateTime StartTime { get; set; }
+    public DateTimeOffset StartTime { get; set; }
 
     [JsonPropertyName("session_id")]
     public int SessionId { get; set; }

--- a/src/Aydsko.iRacingData/Results/SessionInfo.cs
+++ b/src/Aydsko.iRacingData/Results/SessionInfo.cs
@@ -7,32 +7,46 @@ public class SessionInfo
 {
     [JsonPropertyName("subsession_id")]
     public int SubsessionId { get; set; }
+
     [JsonPropertyName("session_id")]
     public int SessionId { get; set; }
+
     [JsonPropertyName("simsession_number")]
     public int SimsessionNumber { get; set; }
+
     [JsonPropertyName("simsession_type")]
     public int SimsessionType { get; set; }
+
     [JsonPropertyName("num_laps_for_qual_average")]
     public int NumLapsForQualAverage { get; set; }
+
     [JsonPropertyName("num_laps_for_solo_average")]
     public int NumLapsForSoloAverage { get; set; }
+
     [JsonPropertyName("event_type")]
     public EventType EventType { get; set; }
+
     [JsonPropertyName("event_type_name")]
     public string EventTypeName { get; set; } = null!;
+
     [JsonPropertyName("private_session_id")]
     public int PrivateSessionId { get; set; }
+
     [JsonPropertyName("season_name")]
     public string SeasonName { get; set; } = null!;
+
     [JsonPropertyName("season_short_name")]
     public string SeasonShortName { get; set; } = null!;
+
     [JsonPropertyName("series_name")]
     public string SeriesName { get; set; } = null!;
+
     [JsonPropertyName("series_short_name")]
     public string SeriesShortName { get; set; } = null!;
+
     [JsonPropertyName("start_time")]
-    public DateTime StartTime { get; set; }
+    public DateTimeOffset StartTime { get; set; }
+
     [JsonPropertyName("track")]
     public Track Track { get; set; } = null!;
 }

--- a/src/Aydsko.iRacingData/Results/SubSessionResult.cs
+++ b/src/Aydsko.iRacingData/Results/SubSessionResult.cs
@@ -9,106 +9,157 @@ public class SubSessionResult
 
     [JsonPropertyName("subsession_id")]
     public int SubSessionId { get; set; }
+
     [JsonPropertyName("season_id")]
     public int SeasonId { get; set; }
+
     [JsonPropertyName("season_name")]
     public string SeasonName { get; set; } = default!;
+
     [JsonPropertyName("season_short_name")]
     public string SeasonShortName { get; set; } = default!;
+
     [JsonPropertyName("season_year")]
     public int SeasonYear { get; set; }
+
     [JsonPropertyName("season_quarter")]
     public int SeasonQuarter { get; set; }
+
     [JsonPropertyName("series_id")]
     public int SeriesId { get; set; }
+
     [JsonPropertyName("series_name")]
     public string SeriesName { get; set; } = default!;
+
     [JsonPropertyName("series_short_name")]
     public string SeriesShortName { get; set; } = default!;
+
     [JsonPropertyName("series_logo")]
     public string SeriesLogo { get; set; } = default!;
+
     [JsonPropertyName("race_week_num")]
     public int RaceWeekNum { get; set; }
+
     [JsonPropertyName("session_id")]
     public int SessionId { get; set; }
+
     [JsonPropertyName("license_category_id")]
     public int LicenseCategoryId { get; set; }
+
     [JsonPropertyName("license_category")]
     public string LicenseCategory { get; set; } = default!;
+
     [JsonPropertyName("private_session_id")]
     public int PrivateSessionId { get; set; }
+
     [JsonPropertyName("start_time")]
-    public DateTime StartTime { get; set; }
+    public DateTimeOffset StartTime { get; set; }
+
     [JsonPropertyName("end_time")]
-    public DateTime EndTime { get; set; }
+    public DateTimeOffset EndTime { get; set; }
+
     [JsonPropertyName("num_laps_for_qual_average")]
     public int NumLapsForQualAverage { get; set; }
+
     [JsonPropertyName("num_laps_for_solo_average")]
     public int NumLapsForSoloAverage { get; set; }
+
     [JsonPropertyName("corners_per_lap")]
     public int CornersPerLap { get; set; }
+
     [JsonPropertyName("caution_type")]
     public int CautionType { get; set; }
+
     [JsonPropertyName("event_type")]
     public EventType EventType { get; set; }
+
     [JsonPropertyName("event_type_name")]
     public string EventTypeName { get; set; } = default!;
+
     [JsonPropertyName("driver_changes")]
     public bool DriverChanges { get; set; }
+
     [JsonPropertyName("min_team_drivers")]
     public int MinTeamDrivers { get; set; }
+
     [JsonPropertyName("max_team_drivers")]
     public int MaxTeamDrivers { get; set; }
+
     [JsonPropertyName("driver_change_rule")]
     public int DriverChangeRule { get; set; }
+
     [JsonPropertyName("driver_change_param1")]
     public int DriverChangeParam1 { get; set; }
+
     [JsonPropertyName("driver_change_param2")]
     public int DriverChangeParam2 { get; set; }
+
     [JsonPropertyName("max_weeks")]
     public int MaxWeeks { get; set; }
+
     [JsonPropertyName("points_type")]
     public string PointsType { get; set; } = default!;
+
     [JsonPropertyName("event_strength_of_field")]
     public int EventStrengthOfField { get; set; }
+
     [JsonPropertyName("event_average_lap")]
     public int EventAverageLap { get; set; }
+
     [JsonPropertyName("event_laps_complete")]
     public int EventLapsComplete { get; set; }
+
     [JsonPropertyName("num_cautions")]
     public int NumCautions { get; set; }
+
     [JsonPropertyName("num_caution_laps")]
     public int NumCautionLaps { get; set; }
+
     [JsonPropertyName("num_lead_changes")]
     public int NumLeadChanges { get; set; }
+
     [JsonPropertyName("official_session")]
     public bool OfficialSession { get; set; }
+
     [JsonPropertyName("heat_info_id")]
     public int HeatInfoId { get; set; }
+
     [JsonPropertyName("special_event_type")]
     public int SpecialEventType { get; set; }
+
     [JsonPropertyName("damage_model")]
     public int DamageModel { get; set; }
+
     [JsonPropertyName("can_protest")]
     public bool CanProtest { get; set; }
+
     [JsonPropertyName("cooldown_minutes")]
     public int CooldownMinutes { get; set; }
+
     [JsonPropertyName("limit_minutes")]
     public int LimitMinutes { get; set; }
+
     [JsonPropertyName("track")]
     public Track Track { get; set; } = default!;
+
     [JsonPropertyName("weather")]
     public Weather Weather { get; set; } = default!;
+
     [JsonPropertyName("track_state")]
     public TrackState TrackState { get; set; } = default!;
+
     [JsonPropertyName("session_results")]
     public SessionResults[] SessionResults { get; set; } = default!;
+
     [JsonPropertyName("race_summary")]
     public RaceSummary RaceSummary { get; set; } = default!;
+
     [JsonPropertyName("car_classes")]
     public ResultsCarClasses[] CarClasses { get; set; } = default!;
+
     [JsonPropertyName("allowed_licenses")]
     public AllowedLicenses[] AllowedLicenses { get; set; } = default!;
+
     [JsonPropertyName("results_restricted")]
     public bool ResultsRestricted { get; set; }
 }

--- a/src/Aydsko.iRacingData/Series/Weather.cs
+++ b/src/Aydsko.iRacingData/Series/Weather.cs
@@ -7,34 +7,49 @@ public class Weather
 {
     [JsonPropertyName("type")]
     public int Type { get; set; }
+
     [JsonPropertyName("temp_units")]
     public int TempUnits { get; set; }
+
     [JsonPropertyName("temp_value")]
     public int TempValue { get; set; }
+
     [JsonPropertyName("rel_humidity")]
     public int RelHumidity { get; set; }
+
     [JsonPropertyName("fog")]
     public int Fog { get; set; }
+
     [JsonPropertyName("wind_dir")]
     public int WindDir { get; set; }
+
     [JsonPropertyName("wind_units")]
     public int WindUnits { get; set; }
+
     [JsonPropertyName("wind_value")]
     public int WindValue { get; set; }
+
     [JsonPropertyName("skies")]
     public int Skies { get; set; }
+
     [JsonPropertyName("weather_var_initial")]
     public int WeatherVarInitial { get; set; }
+
     [JsonPropertyName("weather_var_ongoing")]
     public int WeatherVarOngoing { get; set; }
+
     [JsonPropertyName("time_of_day")]
     public int TimeOfDay { get; set; }
+
     [JsonPropertyName("simulated_start_time")]
     public DateTime SimulatedStartTime { get; set; }
+
     [JsonPropertyName("simulated_time_offsets")]
     public int[] SimulatedTimeOffsets { get; set; } = Array.Empty<int>();
+
     [JsonPropertyName("simulated_time_multiplier")]
     public int SimulatedTimeMultiplier { get; set; }
+
     [JsonPropertyName("simulated_start_utc_time")]
     public DateTimeOffset SimulatedStartUtcTime { get; set; }
 }

--- a/src/Aydsko.iRacingData/Stats/Race.cs
+++ b/src/Aydsko.iRacingData/Stats/Race.cs
@@ -29,7 +29,7 @@ public class Race
     public int LicenseLevel { get; set; }
 
     [JsonPropertyName("session_start_time")]
-    public DateTime SessionStartTime { get; set; }
+    public DateTimeOffset SessionStartTime { get; set; }
 
     [JsonPropertyName("winner_group_id")]
     public int WinnerGroupId { get; set; }

--- a/src/Aydsko.iRacingData/Stats/SeasonDriverStandingsHeader.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonDriverStandingsHeader.cs
@@ -33,7 +33,7 @@ public class SeasonDriverStandingsHeader
     public ChunkInfo ChunkInfo { get; set; } = null!;
 
     [JsonPropertyName("last_updated")]
-    public DateTime LastUpdated { get; set; }
+    public DateTimeOffset LastUpdated { get; set; }
 }
 
 [JsonSerializable(typeof(SeasonDriverStandingsHeader)), JsonSourceGenerationOptions(WriteIndented = true)]

--- a/src/Aydsko.iRacingData/Stats/SeasonQualifyResultsHeader.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonQualifyResultsHeader.cs
@@ -33,7 +33,7 @@ public class SeasonQualifyResultsHeader
     public ChunkInfo ChunkInfo { get; set; } = null!;
 
     [JsonPropertyName("last_updated")]
-    public DateTime LastUpdated { get; set; }
+    public DateTimeOffset LastUpdated { get; set; }
 }
 
 [JsonSerializable(typeof(SeasonQualifyResultsHeader)), JsonSourceGenerationOptions(WriteIndented = true)]

--- a/src/Aydsko.iRacingData/Stats/SeasonTeamStandingsHeader.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonTeamStandingsHeader.cs
@@ -33,7 +33,7 @@ public class SeasonTeamStandingsHeader
     public ChunkInfo ChunkInfo { get; set; } = null!;
 
     [JsonPropertyName("last_updated")]
-    public DateTime LastUpdated { get; set; }
+    public DateTimeOffset LastUpdated { get; set; }
 }
 
 [JsonSerializable(typeof(SeasonTeamStandingsHeader)), JsonSourceGenerationOptions(WriteIndented = true)]

--- a/src/Aydsko.iRacingData/Stats/SeasonTimeTrialResultsHeader.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonTimeTrialResultsHeader.cs
@@ -33,7 +33,7 @@ public class SeasonTimeTrialResultsHeader
     public ChunkInfo ChunkInfo { get; set; } = null!;
 
     [JsonPropertyName("last_updated")]
-    public DateTime LastUpdated { get; set; }
+    public DateTimeOffset LastUpdated { get; set; }
 }
 
 [JsonSerializable(typeof(SeasonTimeTrialResultsHeader)), JsonSourceGenerationOptions(WriteIndented = true)]

--- a/src/Aydsko.iRacingData/Stats/SeasonTimeTrialStandingsHeader.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonTimeTrialStandingsHeader.cs
@@ -33,7 +33,7 @@ public class SeasonTimeTrialStandingsHeader
     public ChunkInfo ChunkInfo { get; set; } = null!;
 
     [JsonPropertyName("last_updated")]
-    public DateTime LastUpdated { get; set; }
+    public DateTimeOffset LastUpdated { get; set; }
 }
 
 [JsonSerializable(typeof(SeasonTimeTrialStandingsHeader)), JsonSourceGenerationOptions(WriteIndented = true)]

--- a/src/Aydsko.iRacingData/Tracks/Track.cs
+++ b/src/Aydsko.iRacingData/Tracks/Track.cs
@@ -30,7 +30,7 @@ public class Track
     public int CornersPerLap { get; set; }
 
     [JsonPropertyName("created")]
-    public DateTime Created { get; set; }
+    public DateTimeOffset Created { get; set; }
 
     [JsonPropertyName("free_with_subscription")]
     public bool FreeWithSubscription { get; set; }


### PR DESCRIPTION
The correct .NET data type for a value which is considered an instant is
"DateTimeOffset". Ensure that these are used as appropriate.

Fixes: #51