### PR TITLE
Provide "Race Week Number" Convenience Property

### DIFF
--- a/src/Aydsko.iRacingData/Package Release Notes.txt
+++ b/src/Aydsko.iRacingData/Package Release Notes.txt
@@ -2,7 +2,8 @@
 
  - ???
 
-Fixes:
+Fixes / Changes:
 
  - Fields that are durations (e.g. lap times or intervals) will use the "TimeSpan" data type
  - Fields that are instants (e.g. session start time) will use the "DateTimeOffset" data type
+ - Added "RaceWeekNumber" properties which calculate the actual race week based on the zero-based "RaceWeekIndex"

--- a/src/Aydsko.iRacingData/Results/SeasonRaceResult.cs
+++ b/src/Aydsko.iRacingData/Results/SeasonRaceResult.cs
@@ -7,8 +7,15 @@ namespace Aydsko.iRacingData.Results;
 
 public class SeasonRaceResult
 {
+    /// <summary>An index number identifying the race week.</summary>
+    /// <remarks>The iRacing Data API works with zero-based race weeks, most people will use one-based.</remarks>
+    /// <seealso cref="RaceWeekNumber" />
     [JsonPropertyName("race_week_num")]
-    public int RaceWeekNum { get; set; }
+    public int RaceWeekIndex { get; set; }
+
+    /// <summary>The number of the race week within the season.</summary>
+    [JsonIgnore]
+    public int RaceWeekNumber => RaceWeekIndex + 1;
 
     [JsonPropertyName("event_type")]
     public EventType EventType { get; set; }

--- a/src/Aydsko.iRacingData/Results/SeasonResults.cs
+++ b/src/Aydsko.iRacingData/Results/SeasonResults.cs
@@ -17,8 +17,15 @@ public class SeasonResults
     [JsonPropertyName("season_id")]
     public int SeasonId { get; set; }
 
+    /// <summary>An index number identifying the race week.</summary>
+    /// <remarks>The iRacing Data API works with zero-based race weeks, most people will use one-based.</remarks>
+    /// <seealso cref="RaceWeekNumber" />
     [JsonPropertyName("race_week_num")]
-    public int RaceWeekNumber { get; set; }
+    public int RaceWeekIndex { get; set; }
+
+    /// <summary>The number of the race week within the season.</summary>
+    [JsonIgnore]
+    public int RaceWeekNumber => RaceWeekIndex + 1;
 }
 
 [JsonSerializable(typeof(SeasonResults)), JsonSourceGenerationOptions(WriteIndented = true)]

--- a/src/Aydsko.iRacingData/Results/SubSessionResult.cs
+++ b/src/Aydsko.iRacingData/Results/SubSessionResult.cs
@@ -37,8 +37,15 @@ public class SubSessionResult
     [JsonPropertyName("series_logo")]
     public string SeriesLogo { get; set; } = default!;
 
+    /// <summary>An index number identifying the race week.</summary>
+    /// <remarks>The iRacing Data API works with zero-based race weeks, most people will use one-based.</remarks>
+    /// <seealso cref="RaceWeekNumber" />
     [JsonPropertyName("race_week_num")]
-    public int RaceWeekNum { get; set; }
+    public int RaceWeekIndex { get; set; }
+
+    /// <summary>The number of the race week within the season.</summary>
+    [JsonIgnore]
+    public int RaceWeekNumber => RaceWeekIndex + 1;
 
     [JsonPropertyName("session_id")]
     public int SessionId { get; set; }

--- a/src/Aydsko.iRacingData/Series/RaceWeeks.cs
+++ b/src/Aydsko.iRacingData/Series/RaceWeeks.cs
@@ -9,8 +9,15 @@ public class RaceWeeks
     [JsonPropertyName("season_id")]
     public int SeasonId { get; set; }
 
+    /// <summary>An index number identifying the race week.</summary>
+    /// <remarks>The iRacing Data API works with zero-based race weeks, most people will use one-based.</remarks>
+    /// <seealso cref="RaceWeekNumber" />
     [JsonPropertyName("race_week_num")]
-    public int RaceWeekNum { get; set; }
+    public int RaceWeekIndex { get; set; }
+
+    /// <summary>The number of the race week within the season.</summary>
+    [JsonIgnore]
+    public int RaceWeekNumber => RaceWeekIndex + 1;
 
     [JsonPropertyName("track")]
     public Track Track { get; set; } = default!;

--- a/src/Aydsko.iRacingData/Series/Schedule.cs
+++ b/src/Aydsko.iRacingData/Series/Schedule.cs
@@ -9,14 +9,26 @@ public class Schedule
 {
     [JsonPropertyName("season_id")]
     public int SeasonId { get; set; }
+
+    /// <summary>An index number identifying the race week.</summary>
+    /// <remarks>The iRacing Data API works with zero-based race weeks, most people will use one-based.</remarks>
+    /// <seealso cref="RaceWeekNumber" />
     [JsonPropertyName("race_week_num")]
-    public int RaceWeekNum { get; set; }
+    public int RaceWeekIndex { get; set; }
+
+    /// <summary>The number of the race week within the season.</summary>
+    [JsonIgnore]
+    public int RaceWeekNumber => RaceWeekIndex + 1;
+
     [JsonPropertyName("series_id")]
     public int SeriesId { get; set; }
+
     [JsonPropertyName("series_name")]
     public string SeriesName { get; set; } = default!;
+
     [JsonPropertyName("season_name")]
     public string SeasonName { get; set; } = default!;
+
     [JsonPropertyName("schedule_name")]
     public string ScheduleName { get; set; } = default!;
 
@@ -30,26 +42,37 @@ public class Schedule
 
     [JsonPropertyName("simulated_time_multiplier")]
     public int SimulatedTimeMultiplier { get; set; }
+
     [JsonPropertyName("race_lap_limit")]
     public int? RaceLapLimit { get; set; }
+
     [JsonPropertyName("race_time_limit")]
     public int? RaceTimeLimit { get; set; }
+
     [JsonPropertyName("start_type")]
     public string StartType { get; set; } = default!;
+
     [JsonPropertyName("restart_type")]
     public string RestartType { get; set; } = default!;
+
     [JsonPropertyName("qual_attached")]
     public bool QualAttached { get; set; }
+
     [JsonPropertyName("yellow_flags")]
     public bool YellowFlags { get; set; }
+
     [JsonPropertyName("special_event_type")]
     public int? SpecialEventType { get; set; }
+
     [JsonPropertyName("track")]
     public Track Track { get; set; } = default!;
+
     [JsonPropertyName("weather")]
     public Weather Weather { get; set; } = default!;
+
     [JsonPropertyName("track_state")]
     public TrackState TrackState { get; set; } = default!;
+
     [JsonPropertyName("car_restrictions")]
     public CarRestrictions[] CarRestrictions { get; set; } = Array.Empty<CarRestrictions>();
 }

--- a/src/Aydsko.iRacingData/Stats/SeasonDriverStandingsHeader.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonDriverStandingsHeader.cs
@@ -26,8 +26,15 @@ public class SeasonDriverStandingsHeader
     [JsonPropertyName("car_class_id")]
     public int CarClassId { get; set; }
 
+    /// <summary>An index number identifying the race week.</summary>
+    /// <remarks>The iRacing Data API works with zero-based race weeks, most people will use one-based.</remarks>
+    /// <seealso cref="RaceWeekNumber" />
     [JsonPropertyName("race_week_num")]
-    public int RaceWeekNum { get; set; }
+    public int RaceWeekIndex { get; set; }
+
+    /// <summary>The number of the race week within the season.</summary>
+    [JsonIgnore]
+    public int RaceWeekNumber => RaceWeekIndex + 1;
 
     [JsonPropertyName("chunk_info")]
     public ChunkInfo ChunkInfo { get; set; } = null!;

--- a/src/Aydsko.iRacingData/Stats/SeasonQualifyResultsHeader.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonQualifyResultsHeader.cs
@@ -26,8 +26,15 @@ public class SeasonQualifyResultsHeader
     [JsonPropertyName("car_class_id")]
     public int CarClassId { get; set; }
 
+    /// <summary>An index number identifying the race week.</summary>
+    /// <remarks>The iRacing Data API works with zero-based race weeks, most people will use one-based.</remarks>
+    /// <seealso cref="RaceWeekNumber" />
     [JsonPropertyName("race_week_num")]
-    public int RaceWeekNum { get; set; }
+    public int RaceWeekIndex { get; set; }
+
+    /// <summary>The number of the race week within the season.</summary>
+    [JsonIgnore]
+    public int RaceWeekNumber => RaceWeekIndex + 1;
 
     [JsonPropertyName("chunk_info")]
     public ChunkInfo ChunkInfo { get; set; } = null!;

--- a/src/Aydsko.iRacingData/Stats/SeasonTeamStandingsHeader.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonTeamStandingsHeader.cs
@@ -26,8 +26,15 @@ public class SeasonTeamStandingsHeader
     [JsonPropertyName("car_class_id")]
     public int CarClassId { get; set; }
 
+    /// <summary>An index number identifying the race week.</summary>
+    /// <remarks>The iRacing Data API works with zero-based race weeks, most people will use one-based.</remarks>
+    /// <seealso cref="RaceWeekNumber" />
     [JsonPropertyName("race_week_num")]
-    public int RaceWeekNum { get; set; }
+    public int RaceWeekIndex { get; set; }
+
+    /// <summary>The number of the race week within the season.</summary>
+    [JsonIgnore]
+    public int RaceWeekNumber => RaceWeekIndex + 1;
 
     [JsonPropertyName("chunk_info")]
     public ChunkInfo ChunkInfo { get; set; } = null!;

--- a/src/Aydsko.iRacingData/Stats/SeasonTimeTrialResultsHeader.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonTimeTrialResultsHeader.cs
@@ -26,8 +26,15 @@ public class SeasonTimeTrialResultsHeader
     [JsonPropertyName("car_class_id")]
     public int CarClassId { get; set; }
 
+    /// <summary>An index number identifying the race week.</summary>
+    /// <remarks>The iRacing Data API works with zero-based race weeks, most people will use one-based.</remarks>
+    /// <seealso cref="RaceWeekNumber" />
     [JsonPropertyName("race_week_num")]
-    public int RaceWeekNum { get; set; }
+    public int RaceWeekIndex { get; set; }
+
+    /// <summary>The number of the race week within the season.</summary>
+    [JsonIgnore]
+    public int RaceWeekNumber => RaceWeekIndex + 1;
 
     [JsonPropertyName("chunk_info")]
     public ChunkInfo ChunkInfo { get; set; } = null!;

--- a/src/Aydsko.iRacingData/Stats/SeasonTimeTrialStandingsHeader.cs
+++ b/src/Aydsko.iRacingData/Stats/SeasonTimeTrialStandingsHeader.cs
@@ -26,8 +26,15 @@ public class SeasonTimeTrialStandingsHeader
     [JsonPropertyName("car_class_id")]
     public int CarClassId { get; set; }
 
+    /// <summary>An index number identifying the race week.</summary>
+    /// <remarks>The iRacing Data API works with zero-based race weeks, most people will use one-based.</remarks>
+    /// <seealso cref="RaceWeekNumber" />
     [JsonPropertyName("race_week_num")]
-    public int RaceWeekNum { get; set; }
+    public int RaceWeekIndex { get; set; }
+
+    /// <summary>The number of the race week within the season.</summary>
+    [JsonIgnore]
+    public int RaceWeekNumber => RaceWeekIndex + 1;
 
     [JsonPropertyName("chunk_info")]
     public ChunkInfo ChunkInfo { get; set; } = null!;


### PR DESCRIPTION
The iRacing Data API operates using zero-based race week numbers. For most display or processing purposes people will prefer to work with a one-based count.

This change adds a convenience method which can be used to directly display or work with the actual one-based week number instead of the zero-based "index".

Fixes: #52