### PR TITLE
Use PR Branch As PreRelease Version

### DIFF
--- a/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
+++ b/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
@@ -20,6 +20,10 @@
     <PackageReleaseNotes Condition="Exists('$(MSBuildProjectDirectory)/Package Release Notes.txt')">$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/Package Release Notes.txt"))</PackageReleaseNotes>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(CI)' == 'true' And '$(GITHUB_HEAD_REF)' != ''">
+    <MinVerDefaultPreReleasePhase>$(GITHUB_HEAD_REF)</MinVerDefaultPreReleasePhase>
+  </PropertyGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Aydsko.iRacingData.UnitTests</_Parameter1>


### PR DESCRIPTION
Avoid duplicates due to automatic version number incrementing. These settings should configure PR builds to match the name of the branch. This should avoid issues when a single commit PR build generates the same version number due to a same height.