### PR TITLE
Improve handling unauthorized responses

### DIFF
--- a/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
@@ -672,6 +672,19 @@ public class CapturedResponseValidationTests : MockedHttpTestBase
     }
 
     [Test(TestOf = typeof(DataClient))]
+    public async Task GetSubSessionResultUnauthorizedThrowsErrorsAsync()
+    {
+        await MessageHandler.QueueResponsesAsync("ResponseUnauthorized").ConfigureAwait(false);
+
+        Assert.ThrowsAsync<iRacingUnauthorizedResponseException>(async () =>
+        {
+            var lapChartResponse = await sut.GetSubSessionResultAsync(12345, false).ConfigureAwait(false);
+        });
+
+        Assert.False(sut.IsLoggedIn);
+    }
+
+    [Test(TestOf = typeof(DataClient))]
     public async Task GetSubsessionEventLogSuccessfulAsync()
     {
         await MessageHandler.QueueResponsesAsync(nameof(GetSubsessionEventLogSuccessfulAsync)).ConfigureAwait(false);

--- a/src/Aydsko.iRacingData.UnitTests/Responses/ResponseUnauthorized/0.json
+++ b/src/Aydsko.iRacingData.UnitTests/Responses/ResponseUnauthorized/0.json
@@ -1,0 +1,14 @@
+﻿{
+  "headers": {},
+  "content": {
+    "authcode": "51687dfd-1d8e-4faa-bf72-52cb36e4f762",
+    "autoLoginSeries": null,
+    "autoLoginToken": null,
+    "custId": 123456,
+    "email": "test.user@example.com",
+    "ssoCookieDomain": ".iracing.com",
+    "ssoCookieName": "irsso_membersv2",
+    "ssoCookiePath": "/",
+    "ssoCookieValue": "3883fc6a-890c-4c75-981c-84f2f9ebfb41"
+  }
+}

--- a/src/Aydsko.iRacingData.UnitTests/Responses/ResponseUnauthorized/1.json
+++ b/src/Aydsko.iRacingData.UnitTests/Responses/ResponseUnauthorized/1.json
@@ -1,0 +1,11 @@
+{
+  "statuscode": 401,
+  "headers": {
+    "x-ratelimit-remaining": "238",
+    "x-ratelimit-limit": "240",
+    "x-ratelimit-reset": "1657533187"
+  },
+  "content": {
+    "error": "Unauthorized"
+  }
+}

--- a/src/Aydsko.iRacingData/Exceptions/iRacingUnauthorizedResponseException.cs
+++ b/src/Aydsko.iRacingData/Exceptions/iRacingUnauthorizedResponseException.cs
@@ -1,0 +1,30 @@
+﻿// © 2022 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace Aydsko.iRacingData.Exceptions;
+
+[Serializable]
+public class iRacingUnauthorizedResponseException : iRacingDataClientException
+{
+    public static iRacingUnauthorizedResponseException Create()
+    {
+        return new("Requested unauthorized.");
+    }
+
+    public iRacingUnauthorizedResponseException()
+    { }
+
+    public iRacingUnauthorizedResponseException(string message)
+        : base(message)
+    { }
+
+    public iRacingUnauthorizedResponseException(string message, Exception innerException)
+        : base(message, innerException)
+    { }
+
+    protected iRacingUnauthorizedResponseException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        : base(serializationInfo, streamingContext)
+    { }
+}

--- a/src/Aydsko.iRacingData/Exceptions/iRacingUnauthorizedResponseException.cs
+++ b/src/Aydsko.iRacingData/Exceptions/iRacingUnauthorizedResponseException.cs
@@ -10,7 +10,7 @@ public class iRacingUnauthorizedResponseException : iRacingDataClientException
 {
     public static iRacingUnauthorizedResponseException Create()
     {
-        return new("Requested unauthorized.");
+        return new("The iRacing API returned an \"Unauthorized\" response code.");
     }
 
     public iRacingUnauthorizedResponseException()


### PR DESCRIPTION
This will raise a `iRacingUnauthorizedResponseException` instead of the System.Web exception. It will also set `IsLoggedIn` to make the following call try to authenticate itself. Expired sessions will give you unauthorized errors, so if you retry this 2nd call should succeed.