### PR TITLE
Add Integration Tests & Fix Search Failing on No Results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
         shell: pwsh
         working-directory: src
         run: dotnet test -c Release --no-build --collect:"XPlat Code Coverage"
+        env:
+          IRACINGDATA_IRACINGDATA__PASSWORD: ${{ secrets.IRACING_PASSWORD }}
 
       - uses: actions/upload-artifact@v2
         if: success() || failure()

--- a/src/Aydsko.iRacingData.IntegrationTests/Aydsko.iRacingData.IntegrationTests.csproj
+++ b/src/Aydsko.iRacingData.IntegrationTests/Aydsko.iRacingData.IntegrationTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+
+    <UserSecretsId>ff388919-f1d3-4f04-91ae-0e32d61f78d9</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aydsko.iRacingData\Aydsko.iRacingData.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/Aydsko.iRacingData.IntegrationTests/Aydsko.iRacingData.IntegrationTests.csproj
+++ b/src/Aydsko.iRacingData.IntegrationTests/Aydsko.iRacingData.IntegrationTests.csproj
@@ -11,7 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/src/Aydsko.iRacingData.IntegrationTests/BaseIntegrationFixture.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/BaseIntegrationFixture.cs
@@ -1,0 +1,65 @@
+﻿using Aydsko.iRacingData.IntegrationTests.Member;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aydsko.iRacingData.IntegrationTests;
+
+[Category("Integration")]
+public class BaseIntegrationFixture : IDisposable
+{
+    private IConfigurationRoot _configuration;
+    private CookieContainer _cookieContainer;
+    private HttpClientHandler _handler;
+    private HttpClient _httpClient;
+
+    internal DataClient Client { get; private set; }
+    protected IConfigurationRoot Configuration => _configuration;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _configuration = new ConfigurationBuilder()
+                                .SetBasePath(TestContext.CurrentContext.TestDirectory)
+                                .AddJsonFile("appsettings.json", false)
+                                .AddUserSecrets(typeof(MemberInfoTest).Assembly)
+                                .Build();
+
+        _cookieContainer = new CookieContainer();
+        _handler = new HttpClientHandler() { CookieContainer = _cookieContainer, UseCookies = true };
+        _httpClient = new HttpClient(_handler);
+
+        var options = new iRacingDataClientOptions
+        {
+            UserAgentProductName = "Aydsko.iRacingData.IntegrationTests",
+            UserAgentProductVersion = typeof(MemberInfoTest).Assembly.GetName().Version,
+            Username = _configuration["iRacingData:Username"],
+            Password = _configuration["iRacingData:Password"]
+        };
+
+        Client = new DataClient(_httpClient, new TestLogger<DataClient>(), options, _cookieContainer);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            (_httpClient as IDisposable)?.Dispose();
+            _httpClient = null!;
+            (_handler as IDisposable)?.Dispose();
+            _handler = null!;
+        }
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/BaseIntegrationFixture.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/BaseIntegrationFixture.cs
@@ -29,6 +29,7 @@ public class BaseIntegrationFixture : IDisposable
                                 .SetBasePath(TestContext.CurrentContext.TestDirectory)
                                 .AddJsonFile("appsettings.json", false)
                                 .AddUserSecrets(typeof(MemberInfoTest).Assembly)
+                                .AddEnvironmentVariables("IRACINGDATA_")
                                 .Build();
 
         _cookieContainer = new CookieContainer();

--- a/src/Aydsko.iRacingData.IntegrationTests/Member/MemberInfoTest.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Member/MemberInfoTest.cs
@@ -1,0 +1,18 @@
+﻿// © 2022 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.IntegrationTests.Member;
+
+public class MemberInfoTest : BaseIntegrationFixture
+{
+    [Test]
+    public async Task TestMemberInfoAsync()
+    {
+        var memberInfo = await Client.GetMyInfoAsync();
+
+        Assert.That(memberInfo, Is.Not.Null);
+        Assert.That(memberInfo.Data, Is.Not.Null);
+
+        Assert.That(memberInfo.Data.Username, Is.EqualTo(Configuration["iRacingData:Username"]));
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/Results/ResultsSearchSeriesTest.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Results/ResultsSearchSeriesTest.cs
@@ -1,0 +1,50 @@
+﻿// © 2022 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.IntegrationTests.Results;
+
+public class ResultsSearchSeriesTest : BaseIntegrationFixture
+{
+    [Test]
+    public async Task GivenValidSearchParametersTheCorrectResultIsReturned()
+    {
+        var searchParameters = new Searches.OfficialSearchParameters
+        {
+            StartRangeBegin = new DateTime(2022, 6, 1, 0, 0, 0),
+            StartRangeEnd = new DateTime(2022, 6, 30, 23, 59, 59, 999),
+            EventTypes = new[] { 5 },
+            OfficialOnly = true,
+            ParticipantCustomerId = 341554
+        };
+
+        var searchResults = await Client.SearchOfficialResultsAsync(searchParameters);
+
+        Assert.That(searchResults, Is.Not.Null);
+        Assert.That(searchResults.Data.Header, Is.Not.Null);
+        Assert.That(searchResults.Data.Items, Is.Not.Null.Or.Empty);
+        Assert.That(searchResults.Data.Items, Has.Length.EqualTo(10));
+    }
+
+    [Test]
+    public async Task GivenSearchParametersThatResultInZeroResultsTheCorrectResultIsReturned()
+    {
+        var searchParameters = new Searches.OfficialSearchParameters
+        {
+            StartRangeBegin = new DateTime(2022, 6, 1, 0, 0, 0),
+            StartRangeEnd = new DateTime(2022, 6, 30, 23, 59, 59, 999),
+            EventTypes = new[] { 5 },
+            OfficialOnly = true,
+            ParticipantCustomerId = 341554,
+            CategoryIds = new[] { 1 }
+        };
+
+        var searchResults = await Client.SearchOfficialResultsAsync(searchParameters);
+
+        Assert.That(searchResults, Is.Not.Null);
+        Assert.That(searchResults.Data.Header, Is.Not.Null);
+        Assert.That(searchResults.Data.Header.Data.Success, Is.True);
+
+        Assert.That(searchResults.Data.Items, Is.Not.Null);
+        Assert.That(searchResults.Data.Items, Has.Length.EqualTo(0));
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/TestLogger.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/TestLogger.cs
@@ -1,0 +1,29 @@
+﻿// © 2022 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aydsko.iRacingData.IntegrationTests;
+
+public class TestLogger<TCategoryName> : ILogger<TCategoryName>
+{
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (formatter is null)
+        {
+            throw new ArgumentNullException(nameof(formatter));
+        }
+
+        TestContext.Out.WriteLine($"[{logLevel,-11} | {eventId.Id} | {eventId.Name,-26}] {formatter(state, exception)}");
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/Usings.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/src/Aydsko.iRacingData.IntegrationTests/appsettings.json
+++ b/src/Aydsko.iRacingData.IntegrationTests/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "iRacingData": {
+    "Username": "adrian@ayds.com.au",
+    "Password": ""
+  }
+}

--- a/src/Aydsko.iRacingData.UnitTests/Aydsko.iRacingData.UnitTests.csproj
+++ b/src/Aydsko.iRacingData.UnitTests/Aydsko.iRacingData.UnitTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">

--- a/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
+++ b/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
@@ -58,6 +58,7 @@
       <_Parameter4_IsLiteral>true</_Parameter4_IsLiteral>
     </AssemblyAttribute>
     <InternalsVisibleTo Include="LINQPadQuery" />
+    <InternalsVisibleTo Include="Aydsko.iRacingData.IntegrationTests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
+++ b/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
@@ -67,11 +67,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MinVer" Version="3.1.0">
+    <PackageReference Include="MinVer" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="6.0.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Text.Json" Version="6.0.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 

--- a/src/Aydsko.iRacingData/Extensions.cs
+++ b/src/Aydsko.iRacingData/Extensions.cs
@@ -43,14 +43,17 @@ static internal class Extensions
             return;
         }
 
+#pragma warning disable CA1308 // Normalize strings to uppercase
         var parameterStringValue = parameterValue switch
         {
             string stringParam => stringParam,
             DateTime dateTimeParam => dateTimeParam.ToString("yyyy-MM-dd\\THH:mm\\Z", CultureInfo.InvariantCulture),
             Array arrayParam => string.Join(",", GetNonNullValues(arrayParam)),
             IEnumerable<string> enumerableOfString => string.Join(",", enumerableOfString),
+            bool boolParam => boolParam.ToString().ToLowerInvariant(),
             _ => Convert.ToString(parameterValue, CultureInfo.InvariantCulture)
         };
+#pragma warning restore CA1308 // Normalize strings to uppercase
 
         var propNameAttr = paramMemberExp.Member.GetCustomAttributes<JsonPropertyNameAttribute>().FirstOrDefault();
         var parameterName = propNameAttr?.Name ?? paramMemberExp.Member.Name;

--- a/src/iRacing Data API.sln
+++ b/src/iRacing Data API.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		..\.github\workflows\tests-report.yml = ..\.github\workflows\tests-report.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aydsko.iRacingData.IntegrationTests", "Aydsko.iRacingData.IntegrationTests\Aydsko.iRacingData.IntegrationTests.csproj", "{5883CAAD-C11B-417A-B5DC-729867B66916}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{E51A6651-85A3-4ED0-8A1D-A4F59732E4D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E51A6651-85A3-4ED0-8A1D-A4F59732E4D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E51A6651-85A3-4ED0-8A1D-A4F59732E4D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5883CAAD-C11B-417A-B5DC-729867B66916}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5883CAAD-C11B-417A-B5DC-729867B66916}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5883CAAD-C11B-417A-B5DC-729867B66916}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5883CAAD-C11B-417A-B5DC-729867B66916}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The results search call was throwing an exception if there were zero results. Fix this and check it by performing an actual search against the iRacing API using the new integration tests. 