### PR TITLE
Modify iRacing Dollars & Credits to Accept Decimal

### DIFF
--- a/src/Aydsko.iRacingData.UnitTests/Responses/GetMemberInfoSucceedsAsync/2.json
+++ b/src/Aydsko.iRacingData.UnitTests/Responses/GetMemberInfoSucceedsAsync/2.json
@@ -20,8 +20,8 @@
         "last_login": "2022-01-01T00:00:00.000000Z",
         "read_comp_rules": "2019-01-01T00:00:00Z",
         "account": {
-            "ir_dollars": 0,
-            "ir_credits": 0,
+            "ir_dollars": 1.23,
+            "ir_credits": 4.56,
             "status": "active"
         },
         "helmet": {

--- a/src/Aydsko.iRacingData/Member/Account.cs
+++ b/src/Aydsko.iRacingData/Member/Account.cs
@@ -6,10 +6,10 @@ namespace Aydsko.iRacingData.Member;
 public class Account
 {
     [JsonPropertyName("ir_dollars")]
-    public int IRacingDollars { get; set; }
+    public decimal IRacingDollars { get; set; }
 
     [JsonPropertyName("ir_credits")]
-    public int IRacingCredits { get; set; }
+    public decimal IRacingCredits { get; set; }
 
     [JsonPropertyName("status")]
     public string Status { get; set; } = default!;


### PR DESCRIPTION
Create a failing test for the iRacing Dollars & Credits fields by using decimal values then resolve the issue.

Fixes: #127