### PR TITLE
Accept Pre-Hashed Password

### DIFF
--- a/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
+++ b/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
@@ -6,4 +6,18 @@
     <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
     <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.IDataClient.UseUsernameAndPassword(System.String,System.String,System.Boolean)</Target>
+    <Left>lib/net6.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.IDataClient.UseUsernameAndPassword(System.String,System.String,System.Boolean)</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
 </Suppressions>

--- a/src/Aydsko.iRacingData/IDataClient.cs
+++ b/src/Aydsko.iRacingData/IDataClient.cs
@@ -24,6 +24,13 @@ public interface IDataClient
     /// <exception cref="iRacingClientOptionsValueMissingException">Either <paramref name="username"/> or <paramref name="password"/> were <see langword="null"/> or white space.</exception>
     void UseUsernameAndPassword(string username, string password);
 
+    /// <summary>Supply the username and password if they weren't supplied through the <see cref="iRacingDataClientOptions"/> object.</summary>
+    /// <param name="username">iRacing user name to use for authentication.</param>
+    /// <param name="password">Password associated with the iRacing user name used to authenticate.</param>
+    /// <param name="passwordIsEncoded">If <see langword="true" /> indicates the <paramref name="password"/> value is already encoded ready for submission to the iRacing API.</param>
+    /// <exception cref="iRacingClientOptionsValueMissingException">Either <paramref name="username"/> or <paramref name="password"/> were <see langword="null"/> or white space.</exception>
+    void UseUsernameAndPassword(string username, string password, bool passwordIsEncoded);
+
     /// <summary>Retrieves details about the car assets, including image paths and descriptions.</summary>
     /// <param name="cancellationToken">A token to allow the operation to be cancelled.</param>
     /// <returns>A <see cref="DataResponse{TData}"/> containing a dictionary which maps the car identifier to a <see cref="CarAssetDetail"/> object for each car.</returns>

--- a/src/Aydsko.iRacingData/Package Release Notes.txt
+++ b/src/Aydsko.iRacingData/Package Release Notes.txt
@@ -1,11 +1,6 @@
 ﻿Fixes / Changes:
 
- - TODO
-
-
-
-Contributions:
-
- - TODO
+ - Accept Pre-Hashed Password (Issue #130)
+   - Allow a user of the library the ability of using a pre-encoded password rather than the plain text.
 
 Thanks for helping out with pull requests to the library!

--- a/src/Aydsko.iRacingData/iRacingDataClientOptions.cs
+++ b/src/Aydsko.iRacingData/iRacingDataClientOptions.cs
@@ -20,6 +20,10 @@ public class iRacingDataClientOptions
     /// <summary>Password associated with the iRacing user name used to authenticate.</summary>
     public string? Password { get; set; }
 
+    /// <summary>If <see langword="true" /> indicates the <see cref="Password"/> property value is already encoded ready for submission to the iRacing API.</summary>
+    /// <seealso href="https://forums.iracing.com/discussion/22109/login-form-changes/p1" />
+    public bool PasswordIsEncoded { get; set; }
+
     /// <summary>Called to retrieve cookie values stored from a previous authentication.</summary>
     public Func<CookieCollection>? RestoreCookies { get; set; }
 


### PR DESCRIPTION
Give the user of the library an option to supply a pre-encoded password value suitable for passing directly to iRacing's API. This opens the possibility of running the library without the system it operates on ever knowing the plain-text password.
