### PR TITLE
Document "TrackConfigLength" and Convert to km

### DIFF
--- a/src/Aydsko.iRacingData.IntegrationTests/Tracks/GetTracksTests.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Tracks/GetTracksTests.cs
@@ -1,0 +1,34 @@
+﻿using Aydsko.iRacingData.Tracks;
+
+namespace Aydsko.iRacingData.IntegrationTests.Tracks;
+
+public class GetTracksTests : BaseIntegrationFixture
+{
+    private Track[] tracksData;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        var tracksResponse = await Client.GetTracksAsync(CancellationToken.None);
+        tracksData = tracksResponse.Data;
+    }
+
+    [TestCaseSource(nameof(GetTestCases))]
+    public decimal? CheckTrackLength(int trackId)
+    {
+        var track = tracksData.SingleOrDefault(t => t.TrackId == trackId);
+        return track?.TrackConfigLengthKm;
+    }
+
+    private static IEnumerable<TestCaseData> GetTestCases()
+    {
+        yield return new(390) { ExpectedResult = 4.57M };
+        yield return new(391) { ExpectedResult = 3.68M };
+        yield return new(197) { ExpectedResult = 1.39M };
+        yield return new(152) { ExpectedResult = 4.44M };
+        yield return new(151) { ExpectedResult = 1.44M };
+        yield return new(95) { ExpectedResult = 5.95M };
+        yield return new(50) { ExpectedResult = 6.51M };
+        yield return new(341) { ExpectedResult = 5.89M };
+    }
+}

--- a/src/Aydsko.iRacingData/Package Release Notes.txt
+++ b/src/Aydsko.iRacingData/Package Release Notes.txt
@@ -1,3 +1,3 @@
 ﻿Fixes / Changes:
 
- - REVERT: "LicenseChangeOval" and "LicenseChangeRoad" changed from an integer to boolean on "Result" and "DriverResult" types.
+ - Added documentation to `Tracks.Track.TrackConfigLength` and added `Tracks.Track.TrackConfigLengthKm` (Issue #132 https://github.com/AdrianJSClark/aydsko-iracingdata/issues/132)

--- a/src/Aydsko.iRacingData/Tracks/Track.cs
+++ b/src/Aydsko.iRacingData/Tracks/Track.cs
@@ -141,8 +141,13 @@ public class Track
     [JsonPropertyName("time_zone")]
     public string TimeZone { get; set; } = default!;
 
+    /// <summary>The length of this track configuration in miles.</summary>
     [JsonPropertyName("track_config_length")]
-    public float TrackConfigLength { get; set; }
+    public decimal TrackConfigLength { get; set; }
+
+    /// <summary>The length of this track configuration converted to kilometres.</summary>
+    [JsonIgnore]
+    public decimal TrackConfigLengthKm => Math.Truncate(TrackConfigLength * 160.9344M) / 100;
 
     [JsonPropertyName("track_dirpath")]
     public string TrackDirpath { get; set; } = default!;


### PR DESCRIPTION
Include documentation about the `Track.TrackConfigLength` and add a `Track.TrackConfigLengthKm` property that converts the initial property value, which is in "miles", to "kilometres".

Fixes: #132 