### PR TITLE
Rework Builds

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -1,15 +1,7 @@
 name: Build Aydsko iRacing Data API
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
-    branches:
-      - main
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:
@@ -74,23 +66,14 @@ jobs:
         shell: pwsh
         run: Get-ChildItem -Path src\*\bin\Release\* -Recurse -Include *.nupkg | Copy-Item -Container:$false
 
-      - name: Push Pre-Release Package to GitHub Packages
-        if: steps.build-solution.outputs.PRERELEASE == 'true' && (format('{0}', env.PACKAGE_KEY) != '')
-        shell: pwsh
-        run: dotnet nuget push *.nupkg --api-key ${{ env.PACKAGE_KEY }} --source "https://nuget.pkg.github.com/AdrianJSClark/index.json"
-        env:
-            PACKAGE_KEY: ${{ secrets.PACKAGE_UPLOAD }}
-
-      - name: 'Create Draft Release'
-        if: ${{ steps.build-solution.outputs.PRERELEASE == 'false' }}
-        shell: pwsh
-        # Can't just use wildcard in this command due to https://github.com/cli/cli/issues/5099 so use Get-Item
-        run: gh release create --draft --title "${{ steps.build-solution.outputs.BUILDVERSION }}" --notes-file "src\Aydsko.iRacingData\Package Release Notes.txt" "release-${{ steps.build-solution.outputs.BUILDVERSION }}" (Get-Item *.nupkg)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: 'Upload Artifacts'
         uses: actions/upload-artifact@v2
         with:
           name: NuGet Packages
           path: Aydsko.*.nupkg
+
+      - name: 'Upload Release Notes'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Release Notes
+          path: 'src\Aydsko.iRacingData\Package Release Notes.txt'

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -47,11 +47,12 @@ jobs:
         env:
           IRACINGDATA_IRACINGDATA__PASSWORD: ${{ secrets.IRACING_PASSWORD }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: test-results
-          path: '**\TestResults\**\*.trx'
+          name: '.NET Tests'
+          path: '**/*.trx'
+          reporter: 'dotnet-trx'
 
       - name: 'Copy Package to Root'
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,6 @@ jobs:
     name: Build & Test
     uses: ./.github/workflows/_build.yml
 
-  report:
-    name: Publish Test Results
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
-
-      - uses: dorny/test-reporter@v1
-        with:
-          name: '.NET Tests'
-          path: '**/*.trx'
-          reporter: 'dotnet-trx'
-
   deploy:
     name: Deploy Pre-Release NuGet Packages to Repository Packages
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: Build & Publish Pre-Release (main)
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & Test
+    uses: ./.github/workflows/_build.yml
+
+  report:
+    name: Publish Test Results
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v1
+        with:
+          artifact: test-results
+          name: '.NET Tests'
+          path: '**/*.trx'
+          reporter: 'dotnet-trx'
+
+  deploy:
+    name: Deploy Pre-Release NuGet Packages to Repository Packages
+    needs: build
+    runs-on: windows-latest
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v3
+
+      - name: Push Pre-Release Package to GitHub Packages
+        if: (format('{0}', env.PACKAGE_KEY) != '')
+        shell: pwsh
+        run: dotnet nuget push *.nupkg --api-key ${{ env.PACKAGE_KEY }} --source "https://nuget.pkg.github.com/AdrianJSClark/index.json"
+        env:
+            PACKAGE_KEY: ${{ secrets.PACKAGE_UPLOAD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+
       - uses: dorny/test-reporter@v1
         with:
-          artifact: test-results
           name: '.NET Tests'
           path: '**/*.trx'
           reporter: 'dotnet-trx'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,45 @@
+name: Build & Create Release (main)
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & Test
+    uses: ./.github/workflows/_build.yml
+
+  report:
+    name: Publish Test Results
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v1
+        with:
+          artifact: test-results
+          name: '.NET Tests'
+          path: '**/*.trx'
+          reporter: 'dotnet-trx'
+
+  deploy:
+    name: Deploy Pre-Release NuGet Packages to Repository Packages
+    needs: build
+    runs-on: windows-latest
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v3
+
+      - name: Create Draft Release
+        shell: pwsh
+        # Can't just use wildcard in this command due to https://github.com/cli/cli/issues/5099 so use Get-Item
+        run: gh release create --draft --title "${{ github.ref_name }}" --notes-file "**\Release Notes\**\Package Release Notes.txt" "release-${{ github.ref_name }}" (Get-Item *.nupkg)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,20 +13,6 @@ jobs:
     name: Build & Test
     uses: ./.github/workflows/_build.yml
 
-  report:
-    name: Publish Test Results
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
-
-      - uses: dorny/test-reporter@v1
-        with:
-          name: '.NET Tests'
-          path: '**/*.trx'
-          reporter: 'dotnet-trx'
-
   deploy:
     name: Deploy Pre-Release NuGet Packages to Repository Packages
     needs: build

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,9 +18,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+
       - uses: dorny/test-reporter@v1
         with:
-          artifact: test-results
           name: '.NET Tests'
           path: '**/*.trx'
           reporter: 'dotnet-trx'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,17 +11,3 @@ jobs:
   build:
     name: Build & Test
     uses: ./.github/workflows/_build.yml
-
-  report:
-    name: Publish Test Results
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
-
-      - uses: dorny/test-reporter@v1
-        with:
-          name: '.NET Tests'
-          path: '**/*.trx'
-          reporter: 'dotnet-trx'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,9 +17,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+
       - uses: dorny/test-reporter@v1
         with:
-          artifact: test-results
           name: '.NET Tests'
           path: '**/*.trx'
           reporter: 'dotnet-trx'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,12 +1,20 @@
-name: 'Test Report'
+name: Build Pull-Request
+
 on:
-  workflow_run:
-    workflows: ['Build Aydsko iRacing Data API']
-    types:
-      - completed
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
 
 jobs:
+  build:
+    name: Build & Test
+    uses: ./.github/workflows/_build.yml
+
   report:
+    name: Publish Test Results
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: dorny/test-reporter@v1


### PR DESCRIPTION
Restructure the builds to be based around the same build script but include it. This means we can do away with mulitple workflows executing for a single action (e.g. one "build" workflow and one "create release" workflow) and instead a single workflow with multiple jobs can be executed for a single task.

This means a continuous integration build is one workflow with build, test report, and deployment of pre-release, instead of two workflows as it was before.