### PR TITLE
Implements https://members-ng.iracing.com/data/league/season_standings

### DIFF
--- a/src/Aydsko.iRacingData.UnitTests/Aydsko.iRacingData.UnitTests.csproj
+++ b/src/Aydsko.iRacingData.UnitTests/Aydsko.iRacingData.UnitTests.csproj
@@ -24,5 +24,4 @@
   <ItemGroup>
     <EmbeddedResource Include="Responses/**/*.json" />
   </ItemGroup>
-
 </Project>

--- a/src/Aydsko.iRacingData.UnitTests/Responses/GetSeasonStandingsAsync/0.json
+++ b/src/Aydsko.iRacingData.UnitTests/Responses/GetSeasonStandingsAsync/0.json
@@ -1,0 +1,14 @@
+﻿{
+  "headers": {},
+  "content": {
+    "authcode": "51687dfd-1d8e-4faa-bf72-52cb36e4f762",
+    "autoLoginSeries": null,
+    "autoLoginToken": null,
+    "custId": 123456,
+    "email": "test.user@example.com",
+    "ssoCookieDomain": ".iracing.com",
+    "ssoCookieName": "irsso_membersv2",
+    "ssoCookiePath": "/",
+    "ssoCookieValue": "3883fc6a-890c-4c75-981c-84f2f9ebfb41"
+  }
+}

--- a/src/Aydsko.iRacingData.UnitTests/Responses/GetSeasonStandingsAsync/1.json
+++ b/src/Aydsko.iRacingData.UnitTests/Responses/GetSeasonStandingsAsync/1.json
@@ -1,0 +1,8 @@
+{
+    "statuscode": 200,
+    "headers": {},
+  "content": {
+    "link": "https://scorpio-assets.s3.amazonaws.com/production/data-server/cache/data-services/league/season_standings/0d758094-d679-4271-9152-0f691bec7c40?AWSAccessKeyId=AKIAUO6OO4A3357USLO7&Expires=1674756881&Signature=xTfAPhX5bAL%2BNAaTRsiCi2X0TM4%3D",
+    "expires": "2023-01-26T18:27:41.822Z"
+  }
+}

--- a/src/Aydsko.iRacingData.UnitTests/Responses/GetSeasonStandingsAsync/2.json
+++ b/src/Aydsko.iRacingData.UnitTests/Responses/GetSeasonStandingsAsync/2.json
@@ -1,0 +1,63 @@
+{
+  "headers": {},
+  "content": {
+    "car_class_id": 0,
+    "success": true,
+    "season_id": 83697,
+    "car_id": 0,
+    "standings": {
+      "driver_standings": [
+        {
+          "rownum": 1,
+          "position": 1,
+          "driver": {
+            "cust_id": 411093,
+            "display_name": "Dennis Møllegaard Pedersen",
+            "helmet": {
+              "pattern": 61,
+              "color1": "000000",
+              "color2": "fc549f",
+              "color3": "000000",
+              "face_type": 4,
+              "helmet_type": 0
+            }
+          },
+          "car_number": null,
+          "driver_nickname": null,
+          "wins": 1,
+          "average_start": 7,
+          "average_finish": 2,
+          "base_points": 2210,
+          "negative_adjustments": 0,
+          "positive_adjustments": 0,
+          "total_adjustments": 0,
+          "total_points": 2210
+        }
+      ],
+      "team_standings": [
+        {
+          "rownum": 1,
+          "position": 1,
+          "team": {
+            "team_id": -220264,
+            "owner_id": 411093,
+            "team_name": "The Apex Odd Twin",
+            "owner": {
+              "cust_id": 411093,
+              "display_name": "Dennis Møllegaard Pedersen",
+              "helmet": {
+                "pattern": 61,
+                "color1": "000000",
+                "color2": "fc549f",
+                "color3": "000000",
+                "face_type": 4,
+                "helmet_type": 0
+              }
+            }
+          }
+        }
+      ]
+    },
+    "league_id": 8835
+  }
+}

--- a/src/Aydsko.iRacingData/DataClient.cs
+++ b/src/Aydsko.iRacingData/DataClient.cs
@@ -1,4 +1,4 @@
-﻿// © 2022 Adrian Clark
+﻿// © 2023 Adrian Clark
 // This file is licensed to you under the MIT license.
 
 using System.Globalization;
@@ -1771,6 +1771,7 @@ internal class DataClient : IDataClient
         return BuildDataResponse(headers, data, logger, expires);
     }
 
+    /// <inheritdoc />
     public async Task<DataResponse<LeagueSeasonSessions>> GetLeagueSeasonSessionsAsync(int leagueId, int seasonId, bool resultsOnly = false, CancellationToken cancellationToken = default)
     {
         if (!IsLoggedIn)
@@ -1806,5 +1807,38 @@ internal class DataClient : IDataClient
 
         (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(getPastSeasonsForSeriesUrl), PastSeriesResultContext.Default.PastSeriesResult, cancellationToken).ConfigureAwait(false);
         return BuildDataResponse(headers, data.Series, logger, expires);
+    }
+
+    /// <inheritdoc />
+    public async Task<DataResponse<SeasonStandings>> GetSeasonStandingsAsync(int leagueId, int seasonId, int? carClassId = null, int? carId = null, CancellationToken cancellationToken = default)
+    {
+        if (!IsLoggedIn)
+        {
+            await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var queryUrl = "https://members-ng.iracing.com/data/league/season_standings";
+
+        var queryParams = new Dictionary<string, string>
+        {
+            ["league_id"] = leagueId.ToString(CultureInfo.InvariantCulture),
+            ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
+        };
+
+        if (carClassId is not null)
+        {
+            queryParams.Add("car_class_id", carClassId.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (carId is not null)
+        {
+            queryParams.Add("car_id", carId.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParams);
+
+        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), SeasonStandingsContext.Default.SeasonStandings, cancellationToken).ConfigureAwait(false);
+
+        return BuildDataResponse(headers, data, logger, expires);
     }
 }

--- a/src/Aydsko.iRacingData/IDataClient.cs
+++ b/src/Aydsko.iRacingData/IDataClient.cs
@@ -105,6 +105,19 @@ public interface IDataClient
     /// <exception cref="iRacingUnauthorizedResponseException">If the iRacing API returns a <c>401 Unauthorized</c> response.</exception>
     Task<DataResponse<LeagueSeasonSessions>> GetLeagueSeasonSessionsAsync(int leagueId, int seasonId, bool resultsOnly = false, CancellationToken cancellationToken = default);
 
+    /// <summary>Retrieves league's season's standings</summary>
+    /// <param name="leagueId">League Id to return sessions for.</param>
+    /// <param name="seasonId">Season Id to return sessions for.</param>
+    /// <param name="carClassId">If <see langword="true"/> include only sessions which results are available.</param>
+    /// <param name="cancellationToken">A token to allow the operation to be cancelled.</param>
+    /// <param name="carId">A token to allow the operation to be cancelled.</param>
+    /// <param name="cancellationToken">A token to allow the operation to be cancelled.</param>
+    /// <returns>A <see cref="DataResponse{TData}"/> containing <see cref="global::Aydsko.iRacingData.Leagues.SeasonStandings"/>.</returns>
+    /// <exception cref="InvalidOperationException">If the client is not currently authenticated.</exception>
+    /// <exception cref="iRacingDataClientException">If there's a problem processing the result.</exception>
+    /// <exception cref="iRacingUnauthorizedResponseException">If the iRacing API returns a <c>401 Unauthorized</c> response.</exception>
+    Task<DataResponse<SeasonStandings>> GetSeasonStandingsAsync(int leagueId, int seasonId, int? carClassId = null, int? carId = null, CancellationToken cancellationToken = default);
+
     /// <summary>Retrieves a list of the iRacing Divisions.</summary>
     /// <param name="cancellationToken">A token to allow the operation to be cancelled.</param>
     /// <returns>A <see cref="DataResponse{TData}"/> containing an array of <see cref="Division"/> objects.</returns>

--- a/src/Aydsko.iRacingData/Leagues/SeasonStandings.cs
+++ b/src/Aydsko.iRacingData/Leagues/SeasonStandings.cs
@@ -1,0 +1,29 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.Leagues;
+
+public class SeasonStandings
+{
+    [JsonPropertyName("car_class_id")]
+    public int CarClassId { get; set; }
+
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("season_id")]
+    public int SeasonId{ get; set; }
+
+    [JsonPropertyName("car_id")]
+    public int CarId { get; set; }
+
+    [JsonPropertyName("league_id")]
+    public int LeagueId { get; set; }
+
+    [JsonPropertyName("standings")]
+    public SeasonStandingsStandingsDetails Standings { get; set; } = null!;
+}
+
+[JsonSerializable(typeof(SeasonStandings)), JsonSourceGenerationOptions(WriteIndented = true)]
+internal partial class SeasonStandingsContext : JsonSerializerContext
+{ }

--- a/src/Aydsko.iRacingData/Leagues/SeasonStandingsDriver.cs
+++ b/src/Aydsko.iRacingData/Leagues/SeasonStandingsDriver.cs
@@ -1,0 +1,16 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.Leagues;
+
+public class SeasonStandingsDriver
+{
+    [JsonPropertyName("cust_id")]
+    public int CustomerId { get; set; }
+
+    [JsonPropertyName("display_name")]
+    public string DisplayName { get; set; } = default!;
+
+    [JsonPropertyName("helmet")]
+    public Helmet Helmet { get; set; } = default!;
+}

--- a/src/Aydsko.iRacingData/Leagues/SeasonStandingsDriverStandings.cs
+++ b/src/Aydsko.iRacingData/Leagues/SeasonStandingsDriverStandings.cs
@@ -1,0 +1,46 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.Leagues;
+
+public class SeasonStandingsDriverStandings
+{
+    [JsonPropertyName("rownum")]
+    public int RowNumber{ get; set; }
+    
+    [JsonPropertyName("position")]
+    public int Position { get; set; }
+
+    [JsonPropertyName("driver")]
+    public SeasonStandingsDriver Driver { get; set; } = null!;
+
+    [JsonPropertyName("car_number")]
+    public string CarNumber { get; set; } = default!;
+
+    [JsonPropertyName("driver_nickname")]
+    public string DriverNickname { get; set; } = default!;
+
+    [JsonPropertyName("wins")]
+    public int Wins { get; set; }
+
+    [JsonPropertyName("average_start")]
+    public int AverageStart { get; set; }
+
+    [JsonPropertyName("average_finish")]
+    public int AverageFinish { get; set; }
+
+    [JsonPropertyName("base_points")]
+    public int BasePoints { get; set; }
+
+    [JsonPropertyName("negative_adjustments")]
+    public int NegativeAdjustments { get; set; }
+
+    [JsonPropertyName("positive_adjustments")]
+    public int PositiveAdjustments { get; set; }
+
+    [JsonPropertyName("total_adjustments")]
+    public int TotalAdjustments { get; set; }
+
+    [JsonPropertyName("total_points")]
+    public int TotalPoints { get; set; }
+}

--- a/src/Aydsko.iRacingData/Leagues/SeasonStandingsStandingsDetails.cs
+++ b/src/Aydsko.iRacingData/Leagues/SeasonStandingsStandingsDetails.cs
@@ -1,0 +1,12 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.Leagues;
+
+public class SeasonStandingsStandingsDetails
+{
+    [JsonPropertyName("driver_standings")]
+    public SeasonStandingsDriverStandings[] DriverStandings { get; set; } = null!;
+    [JsonPropertyName("team_standings")]
+    public SeasonStandingsTeamStandings[] TeamStandings { get; set; } = null!;
+}

--- a/src/Aydsko.iRacingData/Leagues/SeasonStandingsTeam.cs
+++ b/src/Aydsko.iRacingData/Leagues/SeasonStandingsTeam.cs
@@ -1,0 +1,19 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.Leagues;
+
+public class SeasonStandingsTeam
+{
+    [JsonPropertyName("team_id")]
+    public int TeamId { get; set; }
+
+    [JsonPropertyName("owner_id")]
+    public int OwnerId { get; set; }
+
+    [JsonPropertyName("team_name")]
+    public string TeamName { get; set; } = null!;
+
+    [JsonPropertyName("owner")]
+    public SeasonStandingsDriver Owner { get; set; } = null!;
+}

--- a/src/Aydsko.iRacingData/Leagues/SeasonStandingsTeamStandings.cs
+++ b/src/Aydsko.iRacingData/Leagues/SeasonStandingsTeamStandings.cs
@@ -1,0 +1,43 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.Leagues;
+
+public class SeasonStandingsTeamStandings
+{
+    [JsonPropertyName("rownum")]
+    public int RowNumber { get; set; }
+
+    [JsonPropertyName("position")]
+    public int Position { get; set; }
+
+    [JsonPropertyName("team")]
+    public SeasonStandingsTeam Team { get; set; } = null!;
+
+    [JsonPropertyName("car_number")]
+    public string CarNumber { get; set; } = default!;
+
+    [JsonPropertyName("wins")]
+    public int Wins { get; set; }
+
+    [JsonPropertyName("average_start")]
+    public int AverageStart { get; set; }
+
+    [JsonPropertyName("average_finish")]
+    public int AverageFinish { get; set; }
+
+    [JsonPropertyName("base_points")]
+    public int BasePoints { get; set; }
+
+    [JsonPropertyName("negative_adjustments")]
+    public int NegativeAdjustments { get; set; }
+
+    [JsonPropertyName("positive_adjustments")]
+    public int PositiveAdjustments { get; set; }
+
+    [JsonPropertyName("total_adjustments")]
+    public int TotalAdjustments { get; set; }
+
+    [JsonPropertyName("total_points")]
+    public int TotalPoints { get; set; }
+}


### PR DESCRIPTION
The result returns `roster` it according to IRacing devs this field should be there. Also the team standings includes `driver_nickname` which I am also assuming is a mistake.

The two optional params (`car_id` and `car_class_id`) wasn't tested as I don't have any result with multiclass.