### PR TITLE
Replace "netcoreapp31" With "net48" For Tests 

### DIFF
--- a/src/Aydsko.iRacingData.IntegrationTests/Aydsko.iRacingData.IntegrationTests.csproj
+++ b/src/Aydsko.iRacingData.IntegrationTests/Aydsko.iRacingData.IntegrationTests.csproj
@@ -13,11 +13,17 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aydsko.iRacingData.UnitTests/Aydsko.iRacingData.UnitTests.csproj
+++ b/src/Aydsko.iRacingData.UnitTests/Aydsko.iRacingData.UnitTests.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Aydsko.iRacingData.UnitTests/Converters/JsonConverterTestExtensions.cs
+++ b/src/Aydsko.iRacingData.UnitTests/Converters/JsonConverterTestExtensions.cs
@@ -22,7 +22,7 @@ public static class JsonConverterTestExtensions
     {
         foreach (var (jsonValueBytes, timeValue, name) in examples ?? Enumerable.Empty<(byte[] JsonBytes, T Value, string Name)>())
         {
-            yield return new TestCaseData(timeValue).Returns(jsonValueBytes).SetName("Write Value: " + name);
+            yield return new TestCaseData(timeValue).Returns(System.Text.Encoding.UTF8.GetString(jsonValueBytes)).SetName("Write Value: " + name);
         }
     }
 

--- a/src/Aydsko.iRacingData.UnitTests/Converters/ServiceStatusHistoryItemConverterTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/Converters/ServiceStatusHistoryItemConverterTests.cs
@@ -24,11 +24,10 @@ public class ServiceStatusHistoryItemArrayConverterConverterTests
     }
 
     [Test, TestCaseSource(nameof(WriteValueTestCases))]
-    public byte[] WriteValue(ServiceStatusHistoryItem[] input)
+    public string WriteValue(ServiceStatusHistoryItem[] input)
     {
         var result = input.WriteUsingConverter(_sut);
-        Console.WriteLine(UTF8.GetString(result));
-        return result;
+        return UTF8.GetString(result);
     }
 
     public static IEnumerable<TestCaseData> ReadValueTestCases() => Examples().ToReadValueTestCases();

--- a/src/Aydsko.iRacingData.UnitTests/Converters/StatusTimeStampConverterTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/Converters/StatusTimeStampConverterTests.cs
@@ -26,11 +26,10 @@ public class StatusTimeStampConverterTests
     }
 
     [Test, TestCaseSource(nameof(WriteValueTestCases))]
-    public byte[] WriteValue(DateTimeOffset input)
+    public string WriteValue(DateTimeOffset input)
     {
         var result = input.WriteUsingConverter(_sut);
-        Console.WriteLine(UTF8.GetString(result));
-        return result;
+        return UTF8.GetString(result);
     }
 
     public static IEnumerable<TestCaseData> ReadValueTestCases() => Examples().ToReadValueTestCases();

--- a/src/Aydsko.iRacingData.UnitTests/Converters/StringFromStringOrNumberConverterTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/Converters/StringFromStringOrNumberConverterTests.cs
@@ -26,11 +26,10 @@ public class StringFromStringOrNumberConverterTests
     }
 
     [Test, TestCaseSource(nameof(WriteValueTestCases))]
-    public byte[] WriteValue(string input)
+    public string WriteValue(string input)
     {
         var result = input.WriteUsingConverter(_sut);
-        Console.WriteLine(Encoding.UTF8.GetString(result));
-        return result;
+        return Encoding.UTF8.GetString(result);
     }
 
     public static IEnumerable<TestCaseData> ReadValueTestCases() => Examples().ToReadValueTestCases();

--- a/src/Aydsko.iRacingData.UnitTests/Converters/TenThousandthSecondDurationConverterTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/Converters/TenThousandthSecondDurationConverterTests.cs
@@ -26,11 +26,10 @@ public class TenThousandthSecondDurationConverterTests
     }
 
     [Test, TestCaseSource(nameof(WriteValueTestCases))]
-    public byte[] WriteValue(TimeSpan? input)
+    public string WriteValue(TimeSpan? input)
     {
         var result = input.WriteUsingConverter(_sut);
-        Console.WriteLine(UTF8.GetString(result));
-        return result;
+        return UTF8.GetString(result);
     }
 
     public static IEnumerable<TestCaseData> ReadValueTestCases() => Examples().ToReadValueTestCases();

--- a/src/Aydsko.iRacingData.UnitTests/LoginViaOptionsTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/LoginViaOptionsTests.cs
@@ -34,14 +34,14 @@ public class PasswordEncodingTests : MockedHttpTestBase
         await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetLookupsSuccessfulAsync)).ConfigureAwait(false);
         var lookups = await sut.GetLookupsAsync(CancellationToken.None).ConfigureAwait(false);
 
-        var loginRequest = MessageHandler.Requests.Peek();
-        Assert.That(loginRequest, Is.Not.Null);
+        Assert.That(MessageHandler.RequestContent, Has.Count.GreaterThanOrEqualTo(1));
 
-        var contentStreamTask = loginRequest.Content?.ReadAsStreamAsync() ?? Task.FromResult(Stream.Null);
-        using var requestContentStream = await contentStreamTask.ConfigureAwait(false);
-        Assert.That(requestContentStream, Is.Not.Null.Or.Empty);
+        var request = MessageHandler.RequestContent.Dequeue();
+        Assert.That(request, Is.Not.Null);
 
-        var loginDto = await JsonSerializer.DeserializeAsync<TestLoginDto>(requestContentStream).ConfigureAwait(false);
+        Assert.That(request.ContentStream, Is.Not.Null.Or.Empty);
+
+        var loginDto = await JsonSerializer.DeserializeAsync<TestLoginDto>(request.ContentStream).ConfigureAwait(false);
         Assert.That(loginDto, Is.Not.Null);
 
         Assert.That(loginDto!.Email, Is.EqualTo(username));
@@ -72,14 +72,12 @@ public class PasswordEncodingTests : MockedHttpTestBase
 
         var lookups = await sut.GetLookupsAsync(CancellationToken.None).ConfigureAwait(false);
 
-        var loginRequest = MessageHandler.Requests.Peek();
-        Assert.That(loginRequest, Is.Not.Null);
+        var request = MessageHandler.RequestContent.Peek();
+        Assert.That(request, Is.Not.Null);
 
-        var contentStreamTask = loginRequest.Content?.ReadAsStreamAsync() ?? Task.FromResult(Stream.Null);
-        using var requestContentStream = await contentStreamTask.ConfigureAwait(false);
-        Assert.That(requestContentStream, Is.Not.Null.Or.Empty);
+        Assert.That(request.ContentStream, Is.Not.Null.Or.Empty);
 
-        var loginDto = await JsonSerializer.DeserializeAsync<TestLoginDto>(requestContentStream).ConfigureAwait(false);
+        var loginDto = await JsonSerializer.DeserializeAsync<TestLoginDto>(request.ContentStream).ConfigureAwait(false);
         Assert.That(loginDto, Is.Not.Null);
 
         Assert.That(loginDto!.Email, Is.EqualTo(username));
@@ -110,14 +108,11 @@ public class PasswordEncodingTests : MockedHttpTestBase
 
         var lookups = await sut.GetLookupsAsync(CancellationToken.None).ConfigureAwait(false);
 
-        var loginRequest = MessageHandler.Requests.Peek();
-        Assert.That(loginRequest, Is.Not.Null);
+        var request = MessageHandler.RequestContent.Dequeue();
+        Assert.That(request, Is.Not.Null);
+        Assert.That(request.ContentStream, Is.Not.Null.Or.Empty);
 
-        var contentStreamTask = loginRequest.Content?.ReadAsStreamAsync() ?? Task.FromResult(Stream.Null);
-        using var requestContentStream = await contentStreamTask.ConfigureAwait(false);
-        Assert.That(requestContentStream, Is.Not.Null.Or.Empty);
-
-        var loginDto = await JsonSerializer.DeserializeAsync<TestLoginDto>(requestContentStream).ConfigureAwait(false);
+        var loginDto = await JsonSerializer.DeserializeAsync<TestLoginDto>(request.ContentStream).ConfigureAwait(false);
         Assert.That(loginDto, Is.Not.Null);
 
         Assert.That(loginDto!.Email, Is.EqualTo(username));

--- a/src/Aydsko.iRacingData.UnitTests/MockedHttpMessageHandler.cs
+++ b/src/Aydsko.iRacingData.UnitTests/MockedHttpMessageHandler.cs
@@ -1,7 +1,6 @@
-﻿// © 2022 Adrian Clark
+﻿// © 2023 Adrian Clark
 // This file is licensed to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Reflection;
 using System.Text;
@@ -14,7 +13,7 @@ public class MockedHttpMessageHandler : HttpMessageHandler
     private readonly Assembly ResourceAssembly = typeof(MockedHttpMessageHandler).Assembly;
     private readonly CookieContainer cookieContainer;
 
-    public Queue<HttpRequestMessage> Requests { get; } = new();
+    public Queue<MockedHttpRequest> RequestContent { get; } = new();
     public Queue<HttpResponseMessage> Responses { get; } = new();
 
     public MockedHttpMessageHandler(CookieContainer cookieContainer)
@@ -31,7 +30,7 @@ public class MockedHttpMessageHandler : HttpMessageHandler
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        Requests.Enqueue(request);
+        RequestContent.Enqueue(new MockedHttpRequest(request));
 
 #if NET6_0_OR_GREATER
         if (Responses.TryDequeue(out var response))
@@ -61,7 +60,6 @@ public class MockedHttpMessageHandler : HttpMessageHandler
         return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
     }
 
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Streams need to be available for use.")]
     public async Task QueueResponsesAsync(string testName)
     {
         foreach (var manifestName in ResourceAssembly.GetManifestResourceNames()

--- a/src/Aydsko.iRacingData.UnitTests/MockedHttpRequest.cs
+++ b/src/Aydsko.iRacingData.UnitTests/MockedHttpRequest.cs
@@ -1,0 +1,26 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.UnitTests;
+
+public class MockedHttpRequest
+{
+    public KeyValuePair<string, IEnumerable<string>>[] Headers { get; private set; }
+    public Stream ContentStream { get; private set; }
+
+    public MockedHttpRequest(HttpRequestMessage request)
+    {
+        Headers = request.Headers.ToArray();
+        if (request.Content != null)
+        {
+            var contentStream = new MemoryStream();
+            request.Content.CopyToAsync(contentStream).GetAwaiter().GetResult();
+            contentStream.Position = 0;
+            ContentStream = contentStream;
+        }
+        else
+        {
+            ContentStream = Stream.Null;
+        }
+    }
+}

--- a/src/Aydsko.iRacingData.UnitTests/ServicesTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/ServicesTests.cs
@@ -33,9 +33,10 @@ public class ServicesTests
         //Assert.That(sut.IsLoggedIn, Is.True);
         Assert.That(lookups, Is.Not.Null);
         Assert.That(lookups.Data, Is.Not.Null.Or.Empty);
-        foreach (var request in messageHandler.Requests)
+
+        foreach (var request in messageHandler.RequestContent)
         {
-            Assert.That(request.Headers.UserAgent.ToString(), Is.Not.Null);
+            Assert.That(string.Join(" ", request.Headers.Where(h => h.Key == "User-Agent").SelectMany(h => h.Value)), Is.Not.Null.Or.Empty);
         }
     }
 
@@ -65,10 +66,9 @@ public class ServicesTests
 
         Assert.That(lookups, Is.Not.Null);
         Assert.That(lookups.Data, Is.Not.Null.Or.Empty);
-
-        foreach (var request in messageHandler.Requests)
+        foreach (var request in messageHandler.RequestContent)
         {
-            Assert.That(request.Headers.UserAgent.ToString(), Is.EqualTo($"UserAgentTest/1.0 Aydsko.iRacingDataClient/{typeof(IDataClient).Assembly.GetName().Version?.ToString(3)}"));
+            Assert.That(string.Join(" ", request.Headers.Where(h => h.Key == "User-Agent").SelectMany(h => h.Value)), Is.EqualTo($"UserAgentTest/1.0 Aydsko.iRacingDataClient/{typeof(IDataClient).Assembly.GetName().Version?.ToString(3)}"));
         }
     }
 }

--- a/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
+++ b/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
@@ -72,6 +72,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.IDataClient.GetTimeAttackSeasonsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net6.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Aydsko.iRacingData.IDataClient.GetTimeAttackSeriesAsync(System.Threading.CancellationToken)</Target>
     <Left>lib/net6.0/Aydsko.iRacingData.dll</Left>
     <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
@@ -108,6 +115,13 @@
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Aydsko.iRacingData.IDataClient.GetTimeAttackMemberSeasonResultsAsync(System.Int32,System.Threading.CancellationToken)</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.IDataClient.GetTimeAttackSeasonsAsync(System.Threading.CancellationToken)</Target>
     <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
     <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Aydsko.iRacingData/Converters/StatusTimeStampConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/StatusTimeStampConverter.cs
@@ -27,7 +27,7 @@ public class StatusTimeStampConverter : JsonConverter<DateTimeOffset>
     {
         if (value is DateTimeOffset instant)
         {
-            var rawValue = (instant - Epoch).TotalMilliseconds / 1000;
+            var rawValue = (decimal)(instant - Epoch).TotalMilliseconds / 1000;
             writer.WriteNumberValue(rawValue);
             return;
         }


### PR DESCRIPTION
The unit tests used to run against both `net6.0` and `netcoreapp3.1` where the latter was used to pick up the `netstandard2.0` version of the library.

Now that .NET Core 3.1 has fallen out of support, the only reason to have the `netstandard2.0` target is for .NET Framework compatibility. This means that the unit tests should also execute against .NET Framework. To achieve this, replace the old .NET Core 3.1 target with .NET Framework 4.8 (aka `net48`) to run the `netstandard2.0` target tests.