### PR TITLE
Initial Caching Implementation

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -87,7 +87,7 @@ dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggest
 #Style - Modifier preferences
 
 #when this rule is set to a list of modifiers, prefer the specified ordering.
-csharp_preferred_modifier_order = public,private,async,static,readonly:suggestion
+#csharp_preferred_modifier_order = public,private,async,static,readonly:suggestion
 
 #Style - Pattern matching
 
@@ -139,6 +139,10 @@ csharp_style_prefer_parameter_null_checking = false:suggestion
 csharp_style_prefer_top_level_statements = true:silent
 csharp_space_around_binary_operators = before_and_after
 csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
 
 [*.{cs,vb}]
 dotnet_style_operator_placement_when_wrapping = beginning_of_line

--- a/src/Aydsko.iRacingData.IntegrationTests/Aydsko.iRacingData.IntegrationTests.csproj
+++ b/src/Aydsko.iRacingData.IntegrationTests/Aydsko.iRacingData.IntegrationTests.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Aydsko.iRacingData.IntegrationTests/BaseIntegrationFixture.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/BaseIntegrationFixture.cs
@@ -3,9 +3,7 @@
 
 using System.Net;
 using Aydsko.iRacingData.IntegrationTests.Member;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace Aydsko.iRacingData.IntegrationTests;
 
@@ -13,40 +11,37 @@ namespace Aydsko.iRacingData.IntegrationTests;
 public abstract class BaseIntegrationFixture<TClient> : IDisposable
     where TClient : IDataClient
 {
-    protected IConfigurationRoot _configuration;
-    protected CookieContainer _cookieContainer;
-    protected HttpClientHandler _handler;
-    protected HttpClient _httpClient;
-    protected MemoryCache _memoryCache;
+    protected IConfigurationRoot Configuration { get; set; } = default!;
+    protected CookieContainer CookieContainer { get; set; } = default!;
+    protected HttpClientHandler Handler { get; set; } = default!;
+    protected HttpClient HttpClient { get; set; } = default!;
 
-    internal TClient Client { get; set; }
-
-    protected IConfigurationRoot Configuration => _configuration;
+    internal TClient Client { get; set; } = default!;
 
     protected iRacingDataClientOptions BaseSetUp()
     {
-        _configuration = new ConfigurationBuilder()
+        Configuration = new ConfigurationBuilder()
                                 .SetBasePath(TestContext.CurrentContext.TestDirectory)
                                 .AddJsonFile("appsettings.json", false)
                                 .AddUserSecrets(typeof(MemberInfoTest).Assembly)
                                 .AddEnvironmentVariables("IRACINGDATA_")
                                 .Build();
 
-        _cookieContainer = new CookieContainer();
-        _handler = new HttpClientHandler()
+        CookieContainer = new CookieContainer();
+        Handler = new HttpClientHandler()
         {
-            CookieContainer = _cookieContainer,
+            CookieContainer = CookieContainer,
             UseCookies = true,
             CheckCertificateRevocationList = true
         };
-        _httpClient = new HttpClient(_handler);
+        HttpClient = new HttpClient(Handler);
 
         return new iRacingDataClientOptions
         {
             UserAgentProductName = "Aydsko.iRacingData.IntegrationTests",
             UserAgentProductVersion = typeof(MemberInfoTest).Assembly.GetName().Version,
-            Username = _configuration["iRacingData:Username"],
-            Password = _configuration["iRacingData:Password"]
+            Username = Configuration["iRacingData:Username"],
+            Password = Configuration["iRacingData:Password"]
         };
     }
 
@@ -60,14 +55,11 @@ public abstract class BaseIntegrationFixture<TClient> : IDisposable
     {
         if (disposing)
         {
-            (_httpClient as IDisposable)?.Dispose();
-            _httpClient = null!;
+            (HttpClient as IDisposable)?.Dispose();
+            HttpClient = null!;
 
-            (_handler as IDisposable)?.Dispose();
-            _handler = null!;
-
-            (_memoryCache as IDisposable)?.Dispose();
-            _memoryCache = null!;
+            (Handler as IDisposable)?.Dispose();
+            Handler = null!;
         }
     }
 }

--- a/src/Aydsko.iRacingData.IntegrationTests/BaseIntegrationFixture.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/BaseIntegrationFixture.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using Aydsko.iRacingData.IntegrationTests.Member;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 
 namespace Aydsko.iRacingData.IntegrationTests;
@@ -14,6 +15,7 @@ public class BaseIntegrationFixture : IDisposable
     private CookieContainer _cookieContainer;
     private HttpClientHandler _handler;
     private HttpClient _httpClient;
+    private MemoryCache _memoryCache;
 
     internal DataClient Client { get; private set; }
     protected IConfigurationRoot Configuration => _configuration;
@@ -45,7 +47,9 @@ public class BaseIntegrationFixture : IDisposable
             Password = _configuration["iRacingData:Password"]
         };
 
-        Client = new DataClient(_httpClient, new TestLogger<DataClient>(), options, _cookieContainer);
+        _memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        Client = new CachingDataClient(_httpClient, new TestLogger<CachingDataClient>(), options, _cookieContainer, _memoryCache);
     }
 
     public void Dispose()
@@ -60,8 +64,12 @@ public class BaseIntegrationFixture : IDisposable
         {
             (_httpClient as IDisposable)?.Dispose();
             _httpClient = null!;
+
             (_handler as IDisposable)?.Dispose();
             _handler = null!;
+
+            (_memoryCache as IDisposable)?.Dispose();
+            _memoryCache = null!;
         }
     }
 }

--- a/src/Aydsko.iRacingData.IntegrationTests/CachingIntegrationFixture.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/CachingIntegrationFixture.cs
@@ -1,0 +1,19 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Aydsko.iRacingData.IntegrationTests;
+
+internal class CachingIntegrationFixture : BaseIntegrationFixture<CachingDataClient>
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var options = BaseSetUp();
+
+        _memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        Client = new CachingDataClient(_httpClient, new TestLogger<CachingDataClient>(), options, _cookieContainer, _memoryCache);
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/CachingIntegrationFixture.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/CachingIntegrationFixture.cs
@@ -7,13 +7,21 @@ namespace Aydsko.iRacingData.IntegrationTests;
 
 internal class CachingIntegrationFixture : BaseIntegrationFixture<CachingDataClient>
 {
+    protected IMemoryCache MemoryCache { get; private set; } = default!;
+
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
         var options = BaseSetUp();
 
-        _memoryCache = new MemoryCache(new MemoryCacheOptions());
+        MemoryCache = new MemoryCache(new MemoryCacheOptions());
 
-        Client = new CachingDataClient(_httpClient, new TestLogger<CachingDataClient>(), options, _cookieContainer, _memoryCache);
+        Client = new CachingDataClient(HttpClient, new TestLogger<CachingDataClient>(), options, CookieContainer, MemoryCache);
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        MemoryCache.Dispose();
     }
 }

--- a/src/Aydsko.iRacingData.IntegrationTests/CachingIntegrationFixture.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/CachingIntegrationFixture.cs
@@ -14,7 +14,7 @@ internal class CachingIntegrationFixture : BaseIntegrationFixture<CachingDataCli
     {
         var options = BaseSetUp();
 
-        MemoryCache = new MemoryCache(new MemoryCacheOptions());
+        MemoryCache = new MemoryCache(new MemoryCacheOptions() { TrackStatistics = true });
 
         Client = new CachingDataClient(HttpClient, new TestLogger<CachingDataClient>(), options, CookieContainer, MemoryCache);
     }

--- a/src/Aydsko.iRacingData.IntegrationTests/DataClientIntegrationFixture.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/DataClientIntegrationFixture.cs
@@ -1,0 +1,14 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.IntegrationTests;
+
+internal class DataClientIntegrationFixture : BaseIntegrationFixture<DataClient>
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var options = BaseSetUp();
+        Client = new DataClient(_httpClient, new TestLogger<DataClient>(), options, _cookieContainer);
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/DataClientIntegrationFixture.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/DataClientIntegrationFixture.cs
@@ -9,6 +9,6 @@ internal class DataClientIntegrationFixture : BaseIntegrationFixture<DataClient>
     public void OneTimeSetUp()
     {
         var options = BaseSetUp();
-        Client = new DataClient(_httpClient, new TestLogger<DataClient>(), options, _cookieContainer);
+        Client = new DataClient(HttpClient, new TestLogger<DataClient>(), options, CookieContainer);
     }
 }

--- a/src/Aydsko.iRacingData.IntegrationTests/Lookups/CachingLookupTests.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Lookups/CachingLookupTests.cs
@@ -21,5 +21,12 @@ internal class CachingLookupTests : CachingIntegrationFixture
         Assert.That(clubHistory2.Data, Is.Not.Null);
 
         Assert.That(clubHistory2.Data, Has.Length.EqualTo(42));
+
+        var stats = MemoryCache.GetCurrentStatistics();
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats?.TotalHits, Is.Not.Null.And.EqualTo(1));
+            Assert.That(stats?.TotalMisses, Is.Not.Null.And.EqualTo(1));
+        });
     }
 }

--- a/src/Aydsko.iRacingData.IntegrationTests/Lookups/CachingLookupTests.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Lookups/CachingLookupTests.cs
@@ -1,0 +1,25 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.IntegrationTests.Lookups;
+
+internal class CachingLookupTests : CachingIntegrationFixture
+{
+    [Test]
+    public async Task TestClubHistoryLookupsAsync()
+    {
+        var clubHistory = await Client.GetClubHistoryLookupsAsync(2022, 1).ConfigureAwait(false);
+
+        Assert.That(clubHistory, Is.Not.Null);
+        Assert.That(clubHistory.Data, Is.Not.Null);
+
+        Assert.That(clubHistory.Data, Has.Length.EqualTo(42));
+
+        var clubHistory2 = await Client.GetClubHistoryLookupsAsync(2022, 1).ConfigureAwait(false);
+
+        Assert.That(clubHistory2, Is.Not.Null);
+        Assert.That(clubHistory2.Data, Is.Not.Null);
+
+        Assert.That(clubHistory2.Data, Has.Length.EqualTo(42));
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/Lookups/LookupTests.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Lookups/LookupTests.cs
@@ -14,5 +14,12 @@ public class LookupTests : BaseIntegrationFixture
         Assert.That(clubHistory.Data, Is.Not.Null);
 
         Assert.That(clubHistory.Data, Has.Length.EqualTo(42));
+
+        var clubHistory2 = await Client.GetClubHistoryLookupsAsync(2022, 1).ConfigureAwait(false);
+
+        Assert.That(clubHistory2, Is.Not.Null);
+        Assert.That(clubHistory2.Data, Is.Not.Null);
+
+        Assert.That(clubHistory2.Data, Has.Length.EqualTo(42));
     }
 }

--- a/src/Aydsko.iRacingData.IntegrationTests/Lookups/LookupTests.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Lookups/LookupTests.cs
@@ -3,7 +3,7 @@
 
 namespace Aydsko.iRacingData.IntegrationTests.Lookups;
 
-public class LookupTests : BaseIntegrationFixture
+internal class LookupTests : DataClientIntegrationFixture
 {
     [Test]
     public async Task TestClubHistoryLookupsAsync()
@@ -14,12 +14,5 @@ public class LookupTests : BaseIntegrationFixture
         Assert.That(clubHistory.Data, Is.Not.Null);
 
         Assert.That(clubHistory.Data, Has.Length.EqualTo(42));
-
-        var clubHistory2 = await Client.GetClubHistoryLookupsAsync(2022, 1).ConfigureAwait(false);
-
-        Assert.That(clubHistory2, Is.Not.Null);
-        Assert.That(clubHistory2.Data, Is.Not.Null);
-
-        Assert.That(clubHistory2.Data, Has.Length.EqualTo(42));
     }
 }

--- a/src/Aydsko.iRacingData.IntegrationTests/Member/CachingMemberInfoTest.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Member/CachingMemberInfoTest.cs
@@ -1,0 +1,32 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.IntegrationTests.Member;
+
+internal class CachingMemberInfoTest : CachingIntegrationFixture
+{
+    [Test]
+    public async Task TestMemberInfoAsync()
+    {
+        var memberInfo = await Client.GetMyInfoAsync().ConfigureAwait(false);
+
+        Assert.That(memberInfo, Is.Not.Null);
+        Assert.That(memberInfo.Data, Is.Not.Null);
+
+        Assert.That(memberInfo.Data.Username, Is.EqualTo(Configuration["iRacingData:Username"]));
+
+        var memberInfo2 = await Client.GetMyInfoAsync().ConfigureAwait(false);
+
+        Assert.That(memberInfo2, Is.Not.Null);
+        Assert.That(memberInfo2.Data, Is.Not.Null);
+
+        Assert.That(memberInfo2.Data.Username, Is.EqualTo(Configuration["iRacingData:Username"]));
+
+        var stats = MemoryCache.GetCurrentStatistics();
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats?.TotalHits, Is.Not.Null.And.EqualTo(1));
+            Assert.That(stats?.TotalMisses, Is.Not.Null.And.EqualTo(1));
+        });
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/Member/MemberInfoTest.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Member/MemberInfoTest.cs
@@ -3,7 +3,7 @@
 
 namespace Aydsko.iRacingData.IntegrationTests.Member;
 
-public class MemberInfoTest : BaseIntegrationFixture
+internal class MemberInfoTest : DataClientIntegrationFixture
 {
     [Test]
     public async Task TestMemberInfoAsync()

--- a/src/Aydsko.iRacingData.IntegrationTests/Results/CachingResultsGetTest.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Results/CachingResultsGetTest.cs
@@ -1,0 +1,34 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.IntegrationTests.Results;
+
+internal class CachingResultsGetTest : CachingIntegrationFixture
+{
+    [Test]
+    public async Task GivenAValidSubsessionIdThenAResultIsReturned()
+    {
+        var results = await Client.GetSubSessionResultAsync(50033865, true).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(results, Is.Not.Null);
+            Assert.That(results.Data, Is.Not.Null);
+        });
+
+        var results2 = await Client.GetSubSessionResultAsync(50033865, true).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(results2, Is.Not.Null);
+            Assert.That(results2.Data, Is.Not.Null);
+        });
+
+        var stats = MemoryCache.GetCurrentStatistics();
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats?.TotalHits, Is.Not.Null.And.EqualTo(1));
+            Assert.That(stats?.TotalMisses, Is.Not.Null.And.EqualTo(1));
+        });
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/Results/CachingResultsSearchSeriesTest.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Results/CachingResultsSearchSeriesTest.cs
@@ -1,0 +1,92 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.IntegrationTests.Results;
+
+internal class CachingResultsSearchSeriesTest : CachingIntegrationFixture
+{
+    [Test]
+    public async Task GivenValidSearchParametersTheCorrectResultIsReturned()
+    {
+        var searchParameters = new Searches.OfficialSearchParameters
+        {
+            StartRangeBegin = new DateTime(2022, 6, 1, 0, 0, 0),
+            StartRangeEnd = new DateTime(2022, 6, 30, 23, 59, 59, 999),
+            EventTypes = new[] { 5 },
+            OfficialOnly = true,
+            ParticipantCustomerId = 341554
+        };
+
+        var searchResults = await Client.SearchOfficialResultsAsync(searchParameters).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(searchResults, Is.Not.Null);
+            Assert.That(searchResults.Data.Header, Is.Not.Null);
+            Assert.That(searchResults.Data.Items, Is.Not.Null.Or.Empty);
+            Assert.That(searchResults.Data.Items, Has.Length.EqualTo(10));
+        });
+
+        var searchResults2 = await Client.SearchOfficialResultsAsync(searchParameters).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(searchResults2, Is.Not.Null);
+            Assert.That(searchResults2.Data.Header, Is.Not.Null);
+            Assert.That(searchResults2.Data.Items, Is.Not.Null.Or.Empty);
+            Assert.That(searchResults2.Data.Items, Has.Length.EqualTo(10));
+        });
+
+        var stats = MemoryCache.GetCurrentStatistics();
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats?.TotalHits, Is.Not.Null.And.EqualTo(1));
+            Assert.That(stats?.TotalMisses, Is.Not.Null.And.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task GivenSearchParametersThatResultInZeroResultsTheCorrectResultIsReturned()
+    {
+        var searchParameters = new Searches.OfficialSearchParameters
+        {
+            StartRangeBegin = new DateTime(2022, 6, 1, 0, 0, 0),
+            StartRangeEnd = new DateTime(2022, 6, 30, 23, 59, 59, 999),
+            EventTypes = new[] { 5 },
+            OfficialOnly = true,
+            ParticipantCustomerId = 341554,
+            CategoryIds = new[] { 1 }
+        };
+
+        var searchResults = await Client.SearchOfficialResultsAsync(searchParameters).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(searchResults, Is.Not.Null);
+            Assert.That(searchResults.Data.Header, Is.Not.Null);
+            Assert.That(searchResults.Data.Header.Data.Success, Is.True);
+
+            Assert.That(searchResults.Data.Items, Is.Not.Null);
+            Assert.That(searchResults.Data.Items, Has.Length.EqualTo(0));
+        });
+
+        var searchResults2 = await Client.SearchOfficialResultsAsync(searchParameters).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(searchResults2, Is.Not.Null);
+            Assert.That(searchResults2.Data.Header, Is.Not.Null);
+            Assert.That(searchResults2.Data.Header.Data.Success, Is.True);
+
+            Assert.That(searchResults2.Data.Items, Is.Not.Null);
+            Assert.That(searchResults2.Data.Items, Has.Length.EqualTo(0));
+        });
+
+        var stats = MemoryCache.GetCurrentStatistics();
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats?.TotalHits, Is.Not.Null.And.EqualTo(1));
+            Assert.That(stats?.TotalMisses, Is.Not.Null.And.EqualTo(1));
+        });
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/Results/CachingResultsSearchSeriesTest.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Results/CachingResultsSearchSeriesTest.cs
@@ -5,7 +5,7 @@ namespace Aydsko.iRacingData.IntegrationTests.Results;
 
 internal class CachingResultsSearchSeriesTest : CachingIntegrationFixture
 {
-    [Test]
+    [Test(TestOf = typeof(DataClient)), Ignore("Not implemented yet.")]
     public async Task GivenValidSearchParametersTheCorrectResultIsReturned()
     {
         var searchParameters = new Searches.OfficialSearchParameters
@@ -45,7 +45,7 @@ internal class CachingResultsSearchSeriesTest : CachingIntegrationFixture
         });
     }
 
-    [Test]
+    [Test(TestOf = typeof(DataClient)), Ignore("Not implemented yet.")]
     public async Task GivenSearchParametersThatResultInZeroResultsTheCorrectResultIsReturned()
     {
         var searchParameters = new Searches.OfficialSearchParameters

--- a/src/Aydsko.iRacingData.IntegrationTests/Results/ResultsGetTest.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Results/ResultsGetTest.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
 
 namespace Aydsko.iRacingData.IntegrationTests.Results;
-public class ResultsGetTest : BaseIntegrationFixture
+
+internal class ResultsGetTest : DataClientIntegrationFixture
 {
     [Test]
     public async Task GivenAValidSubsessionIdThenAResultIsReturned()

--- a/src/Aydsko.iRacingData.IntegrationTests/Results/ResultsSearchSeriesTest.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Results/ResultsSearchSeriesTest.cs
@@ -3,7 +3,7 @@
 
 namespace Aydsko.iRacingData.IntegrationTests.Results;
 
-public class ResultsSearchSeriesTest : BaseIntegrationFixture
+internal class ResultsSearchSeriesTest : DataClientIntegrationFixture
 {
     [Test]
     public async Task GivenValidSearchParametersTheCorrectResultIsReturned()
@@ -19,10 +19,13 @@ public class ResultsSearchSeriesTest : BaseIntegrationFixture
 
         var searchResults = await Client.SearchOfficialResultsAsync(searchParameters).ConfigureAwait(false);
 
-        Assert.That(searchResults, Is.Not.Null);
-        Assert.That(searchResults.Data.Header, Is.Not.Null);
-        Assert.That(searchResults.Data.Items, Is.Not.Null.Or.Empty);
-        Assert.That(searchResults.Data.Items, Has.Length.EqualTo(10));
+        Assert.Multiple(() =>
+        {
+            Assert.That(searchResults, Is.Not.Null);
+            Assert.That(searchResults.Data.Header, Is.Not.Null);
+            Assert.That(searchResults.Data.Items, Is.Not.Null.Or.Empty);
+            Assert.That(searchResults.Data.Items, Has.Length.EqualTo(10));
+        });
     }
 
     [Test]
@@ -40,11 +43,14 @@ public class ResultsSearchSeriesTest : BaseIntegrationFixture
 
         var searchResults = await Client.SearchOfficialResultsAsync(searchParameters).ConfigureAwait(false);
 
-        Assert.That(searchResults, Is.Not.Null);
-        Assert.That(searchResults.Data.Header, Is.Not.Null);
-        Assert.That(searchResults.Data.Header.Data.Success, Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(searchResults, Is.Not.Null);
+            Assert.That(searchResults.Data.Header, Is.Not.Null);
+            Assert.That(searchResults.Data.Header.Data.Success, Is.True);
 
-        Assert.That(searchResults.Data.Items, Is.Not.Null);
-        Assert.That(searchResults.Data.Items, Has.Length.EqualTo(0));
+            Assert.That(searchResults.Data.Items, Is.Not.Null);
+            Assert.That(searchResults.Data.Items, Has.Length.EqualTo(0));
+        });
     }
 }

--- a/src/Aydsko.iRacingData.IntegrationTests/TestLogger.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/TestLogger.cs
@@ -7,7 +7,7 @@ namespace Aydsko.iRacingData.IntegrationTests;
 
 public class TestLogger<TCategoryName> : ILogger<TCategoryName>
 {
-    public IDisposable BeginScope<TState>(TState state)
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
         throw new NotImplementedException();
     }
@@ -25,5 +25,23 @@ public class TestLogger<TCategoryName> : ILogger<TCategoryName>
         }
 
         TestContext.Out.WriteLine($"[{logLevel,-11} | {eventId.Id} | {eventId.Name,-26}] {formatter(state, exception)}");
+    }
+}
+
+public class TestLoggerFactory : ILoggerFactory
+{
+    public void AddProvider(ILoggerProvider provider)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Dispose()
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/Aydsko.iRacingData.IntegrationTests/TestLogger.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/TestLogger.cs
@@ -42,6 +42,11 @@ public class TestLoggerFactory : ILoggerFactory
 
     public void Dispose()
     {
-        throw new NotImplementedException();
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
     }
 }

--- a/src/Aydsko.iRacingData.IntegrationTests/Tracks/CachingGetTracksTests.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Tracks/CachingGetTracksTests.cs
@@ -1,0 +1,24 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.IntegrationTests.Tracks;
+
+internal class CachingGetTracksTests : CachingIntegrationFixture
+{
+    [Test]
+    public async Task GetTracksTest()
+    {
+        var tracksResponse = await Client.GetTracksAsync(CancellationToken.None).ConfigureAwait(false);
+        Assert.That(tracksResponse.Data, Is.Not.Null.Or.Empty);
+
+        var tracksResponse2 = await Client.GetTracksAsync(CancellationToken.None).ConfigureAwait(false);
+        Assert.That(tracksResponse2.Data, Is.Not.Null.Or.Empty);
+
+        var stats = MemoryCache.GetCurrentStatistics();
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats?.TotalHits, Is.Not.Null.And.EqualTo(1));
+            Assert.That(stats?.TotalMisses, Is.Not.Null.And.EqualTo(1));
+        });
+    }
+}

--- a/src/Aydsko.iRacingData.IntegrationTests/Tracks/GetTracksTests.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Tracks/GetTracksTests.cs
@@ -1,8 +1,11 @@
-﻿using Aydsko.iRacingData.Tracks;
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+using Aydsko.iRacingData.Tracks;
 
 namespace Aydsko.iRacingData.IntegrationTests.Tracks;
 
-public class GetTracksTests : BaseIntegrationFixture
+internal class GetTracksTests : DataClientIntegrationFixture
 {
     private Track[] tracksData;
 

--- a/src/Aydsko.iRacingData.IntegrationTests/Tracks/GetTracksTests.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Tracks/GetTracksTests.cs
@@ -2,6 +2,7 @@
 // This file is licensed to you under the MIT license.
 
 using Aydsko.iRacingData.Tracks;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Aydsko.iRacingData.IntegrationTests.Tracks;
 

--- a/src/Aydsko.iRacingData.UnitTests/ServicesTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/ServicesTests.cs
@@ -21,7 +21,7 @@ public class ServicesTests
         {
             options.Username = "test.user@example.com";
             options.Password = "SuperSecretPassword";
-        }).ConfigurePrimaryHttpMessageHandler(services => messageHandler);
+        }, false).ConfigurePrimaryHttpMessageHandler(services => messageHandler);
 
         using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();
@@ -55,7 +55,7 @@ public class ServicesTests
             options.Password = "SuperSecretPassword";
             options.UserAgentProductName = "UserAgentTest";
             options.UserAgentProductVersion = new(1, 0);
-        }).ConfigurePrimaryHttpMessageHandler(services => messageHandler);
+        }, false).ConfigurePrimaryHttpMessageHandler(services => messageHandler);
 
         using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();

--- a/src/Aydsko.iRacingData.UnitTests/TestLogger.cs
+++ b/src/Aydsko.iRacingData.UnitTests/TestLogger.cs
@@ -7,7 +7,7 @@ namespace Aydsko.iRacingData.UnitTests;
 
 public class TestLogger<T> : ILogger<T>
 {
-    public IDisposable BeginScope<TState>(TState state)
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
         return new TestScope();
     }

--- a/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
+++ b/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
@@ -71,6 +71,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Aydsko.iRacingData/CachingDataClient.cs
+++ b/src/Aydsko.iRacingData/CachingDataClient.cs
@@ -1,0 +1,50 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Aydsko.iRacingData;
+
+internal class CachingDataClient : DataClient
+{
+    private readonly IMemoryCache memoryCache;
+    private readonly ILogger<CachingDataClient> logger;
+
+    public CachingDataClient(HttpClient httpClient,
+                             ILogger<CachingDataClient> logger,
+                             iRacingDataClientOptions options,
+                             CookieContainer cookieContainer,
+                             IMemoryCache memoryCache)
+        : base(httpClient, logger, options, cookieContainer)
+    {
+        this.logger = logger;
+        this.memoryCache = memoryCache;
+    }
+
+    async protected override Task<(HttpResponseHeaders Headers, TData Data, DateTimeOffset? Expires)> CreateResponseViaInfoLinkAsync<TData>(Uri infoLinkUri,
+                                                                                                                                      JsonTypeInfo<TData> jsonTypeInfo,
+                                                                                                                                      CancellationToken cancellationToken)
+    {
+        var isHit = true;
+        var result = await memoryCache.GetOrCreateAsync(infoLinkUri, async ce =>
+        {
+            isHit = false;
+            var response = await base.CreateResponseViaInfoLinkAsync(infoLinkUri, jsonTypeInfo, cancellationToken)
+                                     .ConfigureAwait(false);
+
+            if (response.Expires is not null)
+            {
+                ce.SetAbsoluteExpiration((DateTimeOffset)response.Expires!);
+            }
+
+            return response;
+        }).ConfigureAwait(false);
+
+        logger.LogInformation("Cache status for {Url} is {HitStatus}", infoLinkUri, isHit);
+
+        return result;
+    }
+}

--- a/src/Aydsko.iRacingData/DataClient.cs
+++ b/src/Aydsko.iRacingData/DataClient.cs
@@ -1588,15 +1588,12 @@ internal class DataClient : IDataClient
         var infoLink = JsonSerializer.Deserialize(content, LinkResultContext.Default.LinkResult);
         if (infoLink?.Link is null)
         {
-            throw new iRacingDataClientException("Unrecognised result.");
+            throw new iRacingDataClientException("Unrecognized result.");
         }
 
         var data = await httpClient.GetFromJsonAsync(infoLink.Link, jsonTypeInfo, cancellationToken: cancellationToken)
-                                   .ConfigureAwait(false);
-        if (data is null)
-        {
-            throw new iRacingDataClientException("Data not found.");
-        }
+                                   .ConfigureAwait(false)
+                                   ?? throw new iRacingDataClientException("Data not found.");
 
         return (infoLinkResponse.Headers, data, infoLink.Expires);
     }
@@ -1927,12 +1924,9 @@ internal class DataClient : IDataClient
 
         var queryUrl = "https://members-ng.iracing.com/data/time_attack/member_season_results";
 
-        var queryParams = new Dictionary<string, string>
-        {
-            ["ta_comp_season_id"] = competitionSeasonId.ToString(CultureInfo.InvariantCulture),
-        };
-
-        queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParams);
+        var queryParameters = new Dictionary<string, string>();
+        queryParameters.AddParameterIfNotNull("ta_comp_season_id", competitionSeasonId);
+        queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParameters);
 
         (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), TimeAttackMemberSeasonResultArrayContext.Default.TimeAttackMemberSeasonResultArray, cancellationToken).ConfigureAwait(false);
 

--- a/src/Aydsko.iRacingData/DataClient.cs
+++ b/src/Aydsko.iRacingData/DataClient.cs
@@ -82,8 +82,7 @@ internal class DataClient : IDataClient
         }
 
         var carAssetDetailsUrl = new Uri("https://members-ng.iracing.com/data/car/assets");
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(carAssetDetailsUrl, CarAssetDetailDictionaryContext.Default.IReadOnlyDictionaryStringCarAssetDetail, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(carAssetDetailsUrl, CarAssetDetailDictionaryContext.Default.IReadOnlyDictionaryStringCarAssetDetail, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -95,8 +94,7 @@ internal class DataClient : IDataClient
         }
 
         var carInfoUrl = new Uri("https://members-ng.iracing.com/data/car/get");
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(carInfoUrl, CarInfoArrayContext.Default.CarInfoArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(carInfoUrl, CarInfoArrayContext.Default.CarInfoArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -108,8 +106,7 @@ internal class DataClient : IDataClient
         }
 
         var carClassUrl = new Uri("https://members-ng.iracing.com/data/carclass/get");
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(carClassUrl, CarClassArrayContext.Default.CarClassArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(carClassUrl, CarClassArrayContext.Default.CarClassArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -184,8 +181,7 @@ internal class DataClient : IDataClient
             });
         }
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), CombinedSessionsResultContext.Default.CombinedSessionsResult, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), CombinedSessionsResultContext.Default.CombinedSessionsResult, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -198,8 +194,7 @@ internal class DataClient : IDataClient
 
         var queryUrl = "https://members-ng.iracing.com/data/hosted/sessions";
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), HostedSessionsResultContext.Default.HostedSessionsResult, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), HostedSessionsResultContext.Default.HostedSessionsResult, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -216,8 +211,7 @@ internal class DataClient : IDataClient
             ["include_licenses"] = includeLicenses.ToString(),
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(getTrackUrl), LeagueContext.Default.League, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(getTrackUrl), LeagueContext.Default.League, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -241,8 +235,7 @@ internal class DataClient : IDataClient
 
         queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParams);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), LeagePointsSystemsContext.Default.LeagePointsSystems, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), LeagePointsSystemsContext.Default.LeagePointsSystems, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -254,8 +247,7 @@ internal class DataClient : IDataClient
         }
 
         var lookupsUrl = new Uri("https://members-ng.iracing.com/data/lookup/get?weather=weather_wind_speed_units&weather=weather_wind_speed_max&weather=weather_wind_speed_min&licenselevels=licenselevels");
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(lookupsUrl, LookupGroupArrayContext.Default.LookupGroupArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(lookupsUrl, LookupGroupArrayContext.Default.LookupGroupArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -273,8 +265,7 @@ internal class DataClient : IDataClient
         };
 
         var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/lookup/club_history", queryParams);
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), ClubHistoryLookupArrayContext.Default.ClubHistoryLookupArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), ClubHistoryLookupArrayContext.Default.ClubHistoryLookupArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -296,8 +287,7 @@ internal class DataClient : IDataClient
         }
 
         var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/lookup/drivers", queryParams);
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), DriverSearchResultContext.Default.DriverSearchResultArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), DriverSearchResultContext.Default.DriverSearchResultArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -309,8 +299,7 @@ internal class DataClient : IDataClient
         }
 
         var licenseUrl = new Uri("https://members-ng.iracing.com/data/lookup/licenses");
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(licenseUrl, LicenseLookupArrayContext.Default.LicenseLookupArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(licenseUrl, LicenseLookupArrayContext.Default.LicenseLookupArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -332,8 +321,15 @@ internal class DataClient : IDataClient
             ["include_licenses"] = includeLicenses ? "true" : "false",
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(driverInfoRequestUrl), DriverInfoResponseContext.Default.DriverInfoResponse, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data.Drivers, logger, expires);
+        var driverInfoResponse = await CreateResponseViaInfoLinkAsync(new Uri(driverInfoRequestUrl), DriverInfoResponseContext.Default.DriverInfoResponse, cancellationToken).ConfigureAwait(false);
+        return new DataResponse<DriverInfo[]>
+        {
+            Data = driverInfoResponse.Data.Drivers,
+            DataExpires = driverInfoResponse.DataExpires,
+            RateLimitRemaining = driverInfoResponse.RateLimitRemaining,
+            RateLimitReset = driverInfoResponse.RateLimitReset,
+            TotalRateLimit = driverInfoResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -354,8 +350,7 @@ internal class DataClient : IDataClient
             });
         };
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), MemberAwardArrayContext.Default.MemberAwardArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), MemberAwardArrayContext.Default.MemberAwardArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -366,8 +361,7 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
         var memberInfoUrl = new Uri("https://members-ng.iracing.com/data/member/info");
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(memberInfoUrl, MemberInfoContext.Default.MemberInfo, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(memberInfoUrl, MemberInfoContext.Default.MemberInfo, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -386,8 +380,7 @@ internal class DataClient : IDataClient
                 ["cust_id"] = customerId.Value.ToString(CultureInfo.InvariantCulture),
             });
         }
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(memberProfileUrl), MemberProfileContext.Default.MemberProfile, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberProfileUrl), MemberProfileContext.Default.MemberProfile, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -404,8 +397,7 @@ internal class DataClient : IDataClient
             ["include_licenses"] = includeLicenses ? "true" : "false",
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(subSessionResultUrl), SubSessionResultContext.Default.SubSessionResult, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(subSessionResultUrl), SubSessionResultContext.Default.SubSessionResult, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -422,22 +414,22 @@ internal class DataClient : IDataClient
             ["simsession_number"] = simSessionNumber.ToString(CultureInfo.InvariantCulture),
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionLapsHeaderContext.Default.SubsessionLapsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionLapsHeaderContext.Default.SubsessionLapsHeader, cancellationToken).ConfigureAwait(false);
 
         var sessionLapsList = new List<SubsessionChartLap>();
 
-        if (data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
         {
-            var baseChunkUrl = new Uri(data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -451,7 +443,14 @@ internal class DataClient : IDataClient
             }
         }
 
-        return BuildDataResponse<(SubsessionLapsHeader Header, SubsessionChartLap[] Laps)>(headers, (data, sessionLapsList.ToArray()), logger, expires);
+        return new DataResponse<(SubsessionLapsHeader Header, SubsessionChartLap[] Laps)>
+        {
+            Data = (intermediateResponse.Data, sessionLapsList.ToArray()),
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -468,22 +467,22 @@ internal class DataClient : IDataClient
             ["simsession_number"] = simSessionNumber.ToString(CultureInfo.InvariantCulture),
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionEventLogHeaderContext.Default.SubsessionEventLogHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionEventLogHeaderContext.Default.SubsessionEventLogHeader, cancellationToken).ConfigureAwait(false);
 
         var sessionLapsList = new List<SubsessionEventLogItem>();
 
-        if (data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
         {
-            var baseChunkUrl = new Uri(data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -497,7 +496,14 @@ internal class DataClient : IDataClient
             }
         }
 
-        return BuildDataResponse<(SubsessionEventLogHeader Header, SubsessionEventLogItem[] Laps)>(headers, (data, sessionLapsList.ToArray()), logger, expires);
+        return new DataResponse<(SubsessionEventLogHeader Header, SubsessionEventLogItem[] Laps)>
+        {
+            Data = (intermediateResponse.Data, sessionLapsList.ToArray()),
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -509,8 +515,7 @@ internal class DataClient : IDataClient
         }
 
         var seriesUrl = new Uri("https://members-ng.iracing.com/data/series/get");
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(seriesUrl, SeriesDetailArrayContext.Default.SeriesDetailArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(seriesUrl, SeriesDetailArrayContext.Default.SeriesDetailArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -522,8 +527,7 @@ internal class DataClient : IDataClient
         }
 
         var seriesUrl = new Uri("https://members-ng.iracing.com/data/series/assets");
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(seriesUrl, SeriesAssetReadOnlyDictionaryContext.Default.IReadOnlyDictionaryStringSeriesAsset, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(seriesUrl, SeriesAssetReadOnlyDictionaryContext.Default.IReadOnlyDictionaryStringSeriesAsset, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -541,22 +545,22 @@ internal class DataClient : IDataClient
             ["cust_id"] = customerId.ToString(CultureInfo.InvariantCulture),
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionLapsHeaderContext.Default.SubsessionLapsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionLapsHeaderContext.Default.SubsessionLapsHeader, cancellationToken).ConfigureAwait(false);
 
         var sessionLapsList = new List<SubsessionLap>();
 
-        if (data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
         {
-            var baseChunkUrl = new Uri(data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -570,7 +574,14 @@ internal class DataClient : IDataClient
             }
         }
 
-        return BuildDataResponse<(SubsessionLapsHeader Header, SubsessionLap[] Laps)>(headers, (data, sessionLapsList.ToArray()), logger, expires);
+        return new DataResponse<(SubsessionLapsHeader Header, SubsessionLap[] Laps)>
+        {
+            Data = (intermediateResponse.Data, sessionLapsList.ToArray()),
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -588,22 +599,22 @@ internal class DataClient : IDataClient
             ["team_id"] = teamId.ToString(CultureInfo.InvariantCulture),
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionLapsHeaderContext.Default.SubsessionLapsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionLapsHeaderContext.Default.SubsessionLapsHeader, cancellationToken).ConfigureAwait(false);
 
         var sessionLapsList = new List<SubsessionLap>();
 
-        if (data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
         {
-            var baseChunkUrl = new Uri(data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -617,7 +628,14 @@ internal class DataClient : IDataClient
             }
         }
 
-        return BuildDataResponse<(SubsessionLapsHeader Header, SubsessionLap[] Laps)>(headers, (data, sessionLapsList.ToArray()), logger, expires);
+        return new DataResponse<(SubsessionLapsHeader Header, SubsessionLap[] Laps)>
+        {
+            Data = (intermediateResponse.Data, sessionLapsList.ToArray()),
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -633,8 +651,8 @@ internal class DataClient : IDataClient
             ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
             ["event_type"] = eventType.ToString("D"),
         });
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(memberDivisionUrl), MemberDivisionContext.Default.MemberDivision, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberDivisionUrl), MemberDivisionContext.Default.MemberDivision, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -645,8 +663,7 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/stats/member_yearly"), MemberYearlyStatisticsContext.Default.MemberYearlyStatistics, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/stats/member_yearly"), MemberYearlyStatisticsContext.Default.MemberYearlyStatistics, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -671,8 +688,7 @@ internal class DataClient : IDataClient
 
         var memberChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/member/chart_data", parameters);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(memberChartUrl), MemberChartContext.Default.MemberChart, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberChartUrl), MemberChartContext.Default.MemberChart, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -705,11 +721,11 @@ internal class DataClient : IDataClient
 
         var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/world_records", queryParams);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), WorldRecordsHeaderContext.Default.WorldRecordsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), WorldRecordsHeaderContext.Default.WorldRecordsHeader, cancellationToken).ConfigureAwait(false);
 
         var entries = new List<WorldRecordEntry>();
 
-        if (data.Data.ChunkInfo is ChunkInfo { NumberOfChunks: > 0 } chunkInfo)
+        if (intermediateResponse.Data.Data.ChunkInfo is ChunkInfo { NumberOfChunks: > 0 } chunkInfo)
         {
             var baseChunkUrl = new Uri(chunkInfo.BaseDownloadUrl);
 
@@ -734,7 +750,14 @@ internal class DataClient : IDataClient
             }
         }
 
-        return BuildDataResponse<(WorldRecordsHeader Header, WorldRecordEntry[] Entries)>(headers, (data, entries.ToArray()), logger, expires);
+        return new DataResponse<(WorldRecordsHeader Header, WorldRecordEntry[] Entries)>
+        {
+            Data = (intermediateResponse.Data, entries.ToArray()),
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -752,8 +775,7 @@ internal class DataClient : IDataClient
             ["team_id"] = teamId.ToString(CultureInfo.InvariantCulture),
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), TeamInfoContext.Default.TeamInfo, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), TeamInfoContext.Default.TeamInfo, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -779,22 +801,22 @@ internal class DataClient : IDataClient
 
         var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_driver_standings", queryParams);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonDriverStandingsHeaderContext.Default.SeasonDriverStandingsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonDriverStandingsHeaderContext.Default.SeasonDriverStandingsHeader, cancellationToken).ConfigureAwait(false);
 
         var sessionLapsList = new List<SeasonDriverStanding>();
 
-        if (data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
         {
-            var baseChunkUrl = new Uri(data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -808,7 +830,14 @@ internal class DataClient : IDataClient
             }
         }
 
-        return BuildDataResponse<(SeasonDriverStandingsHeader Header, SeasonDriverStanding[] Laps)>(headers, (data, sessionLapsList.ToArray()), logger, expires);
+        return new DataResponse<(SeasonDriverStandingsHeader Header, SeasonDriverStanding[] Laps)>
+        {
+            Data = (intermediateResponse.Data, sessionLapsList.ToArray()),
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -834,22 +863,22 @@ internal class DataClient : IDataClient
 
         var qualifyResultsUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_qualify_results", queryParams);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(qualifyResultsUrl), SeasonQualifyResultsHeaderContext.Default.SeasonQualifyResultsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(qualifyResultsUrl), SeasonQualifyResultsHeaderContext.Default.SeasonQualifyResultsHeader, cancellationToken).ConfigureAwait(false);
 
         var seasonQualifyResults = new List<SeasonQualifyResult>();
 
-        if (data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
         {
-            var baseChunkUrl = new Uri(data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -863,7 +892,14 @@ internal class DataClient : IDataClient
             }
         }
 
-        return BuildDataResponse<(SeasonQualifyResultsHeader Header, SeasonQualifyResult[] Standings)>(headers, (data, seasonQualifyResults.ToArray()), logger, expires);
+        return new DataResponse<(SeasonQualifyResultsHeader Header, SeasonQualifyResult[] Standings)>
+        {
+            Data = (intermediateResponse.Data, seasonQualifyResults.ToArray()),
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -889,22 +925,22 @@ internal class DataClient : IDataClient
 
         var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_tt_results", resultsStatsSearchParams);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonTimeTrialResultsHeaderContext.Default.SeasonTimeTrialResultsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonTimeTrialResultsHeaderContext.Default.SeasonTimeTrialResultsHeader, cancellationToken).ConfigureAwait(false);
 
         var seasonTimeTrialResults = new List<SeasonTimeTrialResult>();
 
-        if (data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
         {
-            var baseChunkUrl = new Uri(data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -918,7 +954,14 @@ internal class DataClient : IDataClient
             }
         }
 
-        return BuildDataResponse<(SeasonTimeTrialResultsHeader Header, SeasonTimeTrialResult[] Standings)>(headers, (data, seasonTimeTrialResults.ToArray()), logger, expires);
+        return new DataResponse<(SeasonTimeTrialResultsHeader Header, SeasonTimeTrialResult[] Standings)>
+        {
+            Data = (intermediateResponse.Data, seasonTimeTrialResults.ToArray()),
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -944,21 +987,21 @@ internal class DataClient : IDataClient
 
         var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_tt_standings", resultsStatsSearchParams);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonTimeTrialStandingsHeaderContext.Default.SeasonTimeTrialStandingsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonTimeTrialStandingsHeaderContext.Default.SeasonTimeTrialStandingsHeader, cancellationToken).ConfigureAwait(false);
 
         var seasonTimeTrialStandings = new List<SeasonTimeTrialStanding>();
 
-        if (data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
         {
-            var baseChunkUrl = new Uri(data.ChunkInfo.BaseDownloadUrl);
-            foreach (var (chunkFileName, index) in data.ChunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
+            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
+            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -972,7 +1015,14 @@ internal class DataClient : IDataClient
             }
         }
 
-        return BuildDataResponse<(SeasonTimeTrialStandingsHeader Header, SeasonTimeTrialStanding[] Standings)>(headers, (data, seasonTimeTrialStandings.ToArray()), logger, expires);
+        return new DataResponse<(SeasonTimeTrialStandingsHeader Header, SeasonTimeTrialStanding[] Standings)>
+        {
+            Data = (intermediateResponse.Data, seasonTimeTrialStandings.ToArray()),
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -990,22 +1040,22 @@ internal class DataClient : IDataClient
             ["race_week_num"] = raceWeekNumber.ToString(CultureInfo.InvariantCulture),
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonTeamStandingsHeaderContext.Default.SeasonTeamStandingsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonTeamStandingsHeaderContext.Default.SeasonTeamStandingsHeader, cancellationToken).ConfigureAwait(false);
 
         var seasonTeamStandings = new List<SeasonTeamStanding>();
 
-        if (data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
         {
-            var baseChunkUrl = new Uri(data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in data.ChunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -1019,7 +1069,14 @@ internal class DataClient : IDataClient
             }
         }
 
-        return BuildDataResponse<(SeasonTeamStandingsHeader Header, SeasonTeamStanding[] Standings)>(headers, (data, seasonTeamStandings.ToArray()), logger, expires);
+        return new DataResponse<(SeasonTeamStandingsHeader Header, SeasonTeamStanding[] Standings)>
+        {
+            Data = (intermediateResponse.Data, seasonTeamStandings.ToArray()),
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -1036,8 +1093,8 @@ internal class DataClient : IDataClient
             ["event_type"] = eventType.ToString("D"),
             ["race_week_num"] = raceWeekNumber.ToString(CultureInfo.InvariantCulture),
         });
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(seasonResultsUrl), SeasonResultsContext.Default.SeasonResults, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(seasonResultsUrl), SeasonResultsContext.Default.SeasonResults, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1053,8 +1110,7 @@ internal class DataClient : IDataClient
             ["include_series"] = includeSeries ? "true" : "false",
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(seasonSeriesUrl), SeasonSeriesArrayContext.Default.SeasonSeriesArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(seasonSeriesUrl), SeasonSeriesArrayContext.Default.SeasonSeriesArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1065,8 +1121,7 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/series/stats_series"), StatisticsSeriesArrayContext.Default.StatisticsSeriesArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/series/stats_series"), StatisticsSeriesArrayContext.Default.StatisticsSeriesArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1095,8 +1150,7 @@ internal class DataClient : IDataClient
             careerStatisticsUrl = QueryHelpers.AddQueryString(careerStatisticsUrl, queryParams);
         }
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(careerStatisticsUrl), MemberBestsContext.Default.MemberBests, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(careerStatisticsUrl), MemberBestsContext.Default.MemberBests, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1115,8 +1169,7 @@ internal class DataClient : IDataClient
                 ["cust_id"] = customerId.Value.ToString(CultureInfo.InvariantCulture),
             });
         }
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(careerStatisticsUrl), MemberCareerContext.Default.MemberCareer, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(careerStatisticsUrl), MemberCareerContext.Default.MemberCareer, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1136,8 +1189,7 @@ internal class DataClient : IDataClient
             });
         }
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(memberRecentRacesUrl), MemberRecentRacesContext.Default.MemberRecentRaces, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberRecentRacesUrl), MemberRecentRacesContext.Default.MemberRecentRaces, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1156,8 +1208,7 @@ internal class DataClient : IDataClient
                 ["cust_id"] = customerId.Value.ToString(CultureInfo.InvariantCulture),
             });
         }
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(memberSummaryUrl), MemberSummaryContext.Default.MemberSummary, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberSummaryUrl), MemberSummaryContext.Default.MemberSummary, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1169,8 +1220,8 @@ internal class DataClient : IDataClient
         }
 
         var getTrackUrl = "https://members-ng.iracing.com/data/track/assets";
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(getTrackUrl), TrackAssetsArrayContext.Default.IReadOnlyDictionaryStringTrackAssets, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(getTrackUrl), TrackAssetsArrayContext.Default.IReadOnlyDictionaryStringTrackAssets, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1182,8 +1233,8 @@ internal class DataClient : IDataClient
         }
 
         var getTrackUrl = "https://members-ng.iracing.com/data/track/get";
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(getTrackUrl), TrackArrayContext.Default.TrackArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(getTrackUrl), TrackArrayContext.Default.TrackArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1418,9 +1469,7 @@ internal class DataClient : IDataClient
 
         var searchLeagueDirectoryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/directory", queryParameters);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(searchLeagueDirectoryUrl), LeagueDirectoryResultPageContext.Default.LeagueDirectoryResultPage, cancellationToken).ConfigureAwait(false);
-
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(searchLeagueDirectoryUrl), LeagueDirectoryResultPageContext.Default.LeagueDirectoryResultPage, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1437,8 +1486,7 @@ internal class DataClient : IDataClient
             ["season_quarter"] = seasonQuarter.ToString(CultureInfo.InvariantCulture),
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(memberSummaryUrl), ListOfSeasonsContext.Default.ListOfSeasons, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberSummaryUrl), ListOfSeasonsContext.Default.ListOfSeasons, cancellationToken).ConfigureAwait(false);
     }
 
     private Exception? ValidateSearchDateRange(DateTime? rangeBegin, DateTime? rangeEnd, string paramName, string rangeBeginFieldName, string rangeEndFieldName)
@@ -1567,7 +1615,7 @@ internal class DataClient : IDataClient
 
     private const string RateLimitExceededContent = "Rate limit exceeded";
 
-    async protected virtual Task<(HttpResponseHeaders Headers, TData Data, DateTimeOffset? Expires)> CreateResponseViaInfoLinkAsync<TData>(Uri infoLinkUri, JsonTypeInfo<TData> jsonTypeInfo, CancellationToken cancellationToken)
+    async protected virtual Task<DataResponse<TData>> CreateResponseViaInfoLinkAsync<TData>(Uri infoLinkUri, JsonTypeInfo<TData> jsonTypeInfo, CancellationToken cancellationToken)
     {
         var infoLinkResponse = await httpClient.GetAsync(infoLinkUri, cancellationToken).ConfigureAwait(false);
 
@@ -1592,7 +1640,7 @@ internal class DataClient : IDataClient
                                    .ConfigureAwait(false)
                                    ?? throw new iRacingDataClientException("Data not found.");
 
-        return (infoLinkResponse.Headers, data, infoLink.Expires);
+        return BuildDataResponse(infoLinkResponse.Headers, data, logger, infoLink.Expires);
     }
 
     private async Task<(HttpResponseHeaders Headers, TData Data)> GetResponseAsync<TData>(Uri iRacingUri, JsonTypeInfo<TData> jsonTypeInfo, CancellationToken cancellationToken)
@@ -1722,8 +1770,7 @@ internal class DataClient : IDataClient
         }
 
         var getMembershipUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/membership", queryString);
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(getMembershipUrl), LeagueMembershipArrayContext.Default.LeagueMembershipArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(getMembershipUrl), LeagueMembershipArrayContext.Default.LeagueMembershipArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1740,8 +1787,7 @@ internal class DataClient : IDataClient
             ["retired"] = includeRetired ? "1" : "0"
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(getLeagueSeasons), LeagueSeasonsContext.Default.LeagueSeasons, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(getLeagueSeasons), LeagueSeasonsContext.Default.LeagueSeasons, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1773,8 +1819,7 @@ internal class DataClient : IDataClient
             raceGuideUrl = QueryHelpers.AddQueryString(raceGuideUrl, queryParams);
         }
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(raceGuideUrl), RaceGuideResultsContext.Default.RaceGuideResults, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(raceGuideUrl), RaceGuideResultsContext.Default.RaceGuideResults, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1787,8 +1832,7 @@ internal class DataClient : IDataClient
 
         var countryUrl = "https://members-ng.iracing.com/data/lookup/countries";
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(countryUrl), CountryArrayContext.Default.CountryArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(countryUrl), CountryArrayContext.Default.CountryArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1801,8 +1845,7 @@ internal class DataClient : IDataClient
 
         var participationCreditsUrl = "https://members-ng.iracing.com/data/member/participation_credits";
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(participationCreditsUrl), ParticipationCreditsArrayContext.Default.ParticipationCreditsArray, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(participationCreditsUrl), ParticipationCreditsArrayContext.Default.ParticipationCreditsArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1820,8 +1863,7 @@ internal class DataClient : IDataClient
             ["results_only"] = resultsOnly ? "1" : "0"
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(getLeagueSeasonSessions), LeagueSeasonSessionsContext.Default.LeagueSeasonSessions, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(getLeagueSeasonSessions), LeagueSeasonSessionsContext.Default.LeagueSeasonSessions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1839,8 +1881,16 @@ internal class DataClient : IDataClient
             ["series_id"] = seriesId.ToString(CultureInfo.InvariantCulture),
         });
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(getPastSeasonsForSeriesUrl), PastSeriesResultContext.Default.PastSeriesResult, cancellationToken).ConfigureAwait(false);
-        return BuildDataResponse(headers, data.Series, logger, expires);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(getPastSeasonsForSeriesUrl), PastSeriesResultContext.Default.PastSeriesResult, cancellationToken).ConfigureAwait(false);
+
+        return new DataResponse<PastSeriesDetail>
+        {
+            Data = intermediateResponse.Data.Series,
+            DataExpires = intermediateResponse.DataExpires,
+            RateLimitRemaining = intermediateResponse.RateLimitRemaining,
+            RateLimitReset = intermediateResponse.RateLimitReset,
+            TotalRateLimit = intermediateResponse.TotalRateLimit
+        };
     }
 
     /// <inheritdoc />
@@ -1871,9 +1921,7 @@ internal class DataClient : IDataClient
 
         queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParams);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), SeasonStandingsContext.Default.SeasonStandings, cancellationToken).ConfigureAwait(false);
-
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), SeasonStandingsContext.Default.SeasonStandings, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1922,9 +1970,7 @@ internal class DataClient : IDataClient
         queryParameters.AddParameterIfNotNull("ta_comp_season_id", competitionSeasonId);
         queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParameters);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), TimeAttackMemberSeasonResultArrayContext.Default.TimeAttackMemberSeasonResultArray, cancellationToken).ConfigureAwait(false);
-
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), TimeAttackMemberSeasonResultArrayContext.Default.TimeAttackMemberSeasonResultArray, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1943,9 +1989,7 @@ internal class DataClient : IDataClient
         queryParameters.AddParameterIfNotNull("season", seasonQuarter);
         queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParameters);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), MemberRecapContext.Default.MemberRecap, cancellationToken).ConfigureAwait(false);
-
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), MemberRecapContext.Default.MemberRecap, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1962,8 +2006,6 @@ internal class DataClient : IDataClient
         queryParameters.AddParameterIfNotNull("event_types", eventTypes);
         queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParameters);
 
-        (var headers, var data, var expires) = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), SpectatorSubsessionIdsContext.Default.SpectatorSubsessionIds, cancellationToken).ConfigureAwait(false);
-
-        return BuildDataResponse(headers, data, logger, expires);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), SpectatorSubsessionIdsContext.Default.SpectatorSubsessionIds, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Aydsko.iRacingData/DataClient.cs
+++ b/src/Aydsko.iRacingData/DataClient.cs
@@ -1570,7 +1570,7 @@ internal class DataClient : IDataClient
 
     private const string RateLimitExceededContent = "Rate limit exceeded";
 
-    private async Task<(HttpResponseHeaders Headers, TData Data, DateTimeOffset? Expires)> CreateResponseViaInfoLinkAsync<TData>(Uri infoLinkUri, JsonTypeInfo<TData> jsonTypeInfo, CancellationToken cancellationToken)
+    protected virtual async Task<(HttpResponseHeaders Headers, TData Data, DateTimeOffset? Expires)> CreateResponseViaInfoLinkAsync<TData>(Uri infoLinkUri, JsonTypeInfo<TData> jsonTypeInfo, CancellationToken cancellationToken)
     {
         var infoLinkResponse = await httpClient.GetAsync(infoLinkUri, cancellationToken).ConfigureAwait(false);
 

--- a/src/Aydsko.iRacingData/DataClient.cs
+++ b/src/Aydsko.iRacingData/DataClient.cs
@@ -81,8 +81,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var carAssetDetailsUrl = new Uri("https://members-ng.iracing.com/data/car/assets");
-        return await CreateResponseViaInfoLinkAsync(carAssetDetailsUrl, CarAssetDetailDictionaryContext.Default.IReadOnlyDictionaryStringCarAssetDetail, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/car/assets"),
+                                                    CarAssetDetailDictionaryContext.Default.IReadOnlyDictionaryStringCarAssetDetail,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -93,8 +94,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var carInfoUrl = new Uri("https://members-ng.iracing.com/data/car/get");
-        return await CreateResponseViaInfoLinkAsync(carInfoUrl, CarInfoArrayContext.Default.CarInfoArray, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/car/get"),
+                                                    CarInfoArrayContext.Default.CarInfoArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -171,17 +173,18 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryUrl = "https://members-ng.iracing.com/data/hosted/combined_sessions";
+        var queryParameters = new Dictionary<string, string>();
 
         if (packageId is not null)
         {
-            queryUrl = QueryHelpers.AddQueryString(queryUrl, new Dictionary<string, string>
-            {
-                ["package_id"] = packageId.Value.ToString(CultureInfo.InvariantCulture)
-            });
+            queryParameters.Add("package_id", packageId.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), CombinedSessionsResultContext.Default.CombinedSessionsResult, cancellationToken).ConfigureAwait(false);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/hosted/combined_sessions", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl),
+                                                    CombinedSessionsResultContext.Default.CombinedSessionsResult,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -192,9 +195,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryUrl = "https://members-ng.iracing.com/data/hosted/sessions";
-
-        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), HostedSessionsResultContext.Default.HostedSessionsResult, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/hosted/sessions"),
+                                                    HostedSessionsResultContext.Default.HostedSessionsResult,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -205,13 +208,17 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var getTrackUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/get", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["league_id"] = leagueId.ToString(CultureInfo.InvariantCulture),
             ["include_licenses"] = includeLicenses.ToString(),
-        });
+        };
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(getTrackUrl), LeagueContext.Default.League, cancellationToken).ConfigureAwait(false);
+        var getLeagueUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/get", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(getLeagueUrl),
+                                                    LeagueContext.Default.League,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -221,19 +228,18 @@ internal class DataClient : IDataClient
         {
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
-        var queryUrl = "https://members-ng.iracing.com/data/league/get_points_systems";
 
-        var queryParams = new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["league_id"] = leagueId.ToString(CultureInfo.InvariantCulture),
         };
 
-        if (seasonId is int seasonIdValue)
+        if (seasonId is not null)
         {
-            queryParams.Add("season_id", seasonIdValue.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("season_id", seasonId.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParams);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/get_points_systems", queryParameters);
 
         return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), LeagePointsSystemsContext.Default.LeagePointsSystems, cancellationToken).ConfigureAwait(false);
     }
@@ -246,8 +252,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var lookupsUrl = new Uri("https://members-ng.iracing.com/data/lookup/get?weather=weather_wind_speed_units&weather=weather_wind_speed_max&weather=weather_wind_speed_min&licenselevels=licenselevels");
-        return await CreateResponseViaInfoLinkAsync(lookupsUrl, LookupGroupArrayContext.Default.LookupGroupArray, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/lookup/get?weather=weather_wind_speed_units&weather=weather_wind_speed_max&weather=weather_wind_speed_min&licenselevels=licenselevels"),
+                                                    LookupGroupArrayContext.Default.LookupGroupArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -258,14 +265,17 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryParams = new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["season_year"] = seasonYear.ToString(CultureInfo.InvariantCulture),
             ["season_quarter"] = seasonQuarter.ToString(CultureInfo.InvariantCulture),
         };
 
-        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/lookup/club_history", queryParams);
-        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), ClubHistoryLookupArrayContext.Default.ClubHistoryLookupArray, cancellationToken).ConfigureAwait(false);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/lookup/club_history", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl),
+                                                    ClubHistoryLookupArrayContext.Default.ClubHistoryLookupArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -276,18 +286,21 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryParams = new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["search_term"] = searchTerm
         };
 
         if (leagueId is not null)
         {
-            queryParams.Add("league_id", leagueId.Value.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("league_id", leagueId.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/lookup/drivers", queryParams);
-        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), DriverSearchResultContext.Default.DriverSearchResultArray, cancellationToken).ConfigureAwait(false);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/lookup/drivers", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl),
+                                                    DriverSearchResultContext.Default.DriverSearchResultArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -298,8 +311,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var licenseUrl = new Uri("https://members-ng.iracing.com/data/lookup/licenses");
-        return await CreateResponseViaInfoLinkAsync(licenseUrl, LicenseLookupArrayContext.Default.LicenseLookupArray, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/lookup/licenses"),
+                                                    LicenseLookupArrayContext.Default.LicenseLookupArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -315,13 +329,18 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var driverInfoRequestUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/member/get", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["cust_ids"] = string.Join(",", customerIds),
             ["include_licenses"] = includeLicenses ? "true" : "false",
-        });
+        };
 
-        var driverInfoResponse = await CreateResponseViaInfoLinkAsync(new Uri(driverInfoRequestUrl), DriverInfoResponseContext.Default.DriverInfoResponse, cancellationToken).ConfigureAwait(false);
+        var driverInfoRequestUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/member/get", queryParameters);
+
+        var driverInfoResponse = await CreateResponseViaInfoLinkAsync(new Uri(driverInfoRequestUrl),
+                                                                      DriverInfoResponseContext.Default.DriverInfoResponse,
+                                                                      cancellationToken).ConfigureAwait(false);
+
         return new DataResponse<DriverInfo[]>
         {
             Data = driverInfoResponse.Data.Drivers,
@@ -340,17 +359,18 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryUrl = "https://members-ng.iracing.com/data/member/awards";
+        var queryParameters = new Dictionary<string, string>();
 
         if (customerId is not null)
         {
-            queryUrl = QueryHelpers.AddQueryString(queryUrl, new Dictionary<string, string>
-            {
-                ["cust_id"] = customerId.Value.ToString(CultureInfo.InvariantCulture),
-            });
+            queryParameters.Add("cust_id", customerId.Value.ToString(CultureInfo.InvariantCulture));
         };
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), MemberAwardArrayContext.Default.MemberAwardArray, cancellationToken).ConfigureAwait(false);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/member/awards", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl),
+                                                    MemberAwardArrayContext.Default.MemberAwardArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -360,8 +380,10 @@ internal class DataClient : IDataClient
         {
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
-        var memberInfoUrl = new Uri("https://members-ng.iracing.com/data/member/info");
-        return await CreateResponseViaInfoLinkAsync(memberInfoUrl, MemberInfoContext.Default.MemberInfo, cancellationToken).ConfigureAwait(false);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/member/info"),
+                                                    MemberInfoContext.Default.MemberInfo,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -371,16 +393,18 @@ internal class DataClient : IDataClient
         {
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
+        var queryParameters = new Dictionary<string, string>();
 
-        var memberProfileUrl = "https://members-ng.iracing.com/data/member/profile";
         if (customerId is not null)
         {
-            memberProfileUrl = QueryHelpers.AddQueryString(memberProfileUrl, new Dictionary<string, string>
-            {
-                ["cust_id"] = customerId.Value.ToString(CultureInfo.InvariantCulture),
-            });
+            queryParameters.Add("cust_id", customerId.Value.ToString(CultureInfo.InvariantCulture));
         }
-        return await CreateResponseViaInfoLinkAsync(new Uri(memberProfileUrl), MemberProfileContext.Default.MemberProfile, cancellationToken).ConfigureAwait(false);
+
+        var memberProfileUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/member/profile", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberProfileUrl),
+                                                    MemberProfileContext.Default.MemberProfile,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -391,13 +415,17 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var subSessionResultUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/get", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["subsession_id"] = subSessionId.ToString(CultureInfo.InvariantCulture),
             ["include_licenses"] = includeLicenses ? "true" : "false",
-        });
+        };
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(subSessionResultUrl), SubSessionResultContext.Default.SubSessionResult, cancellationToken).ConfigureAwait(false);
+        var subSessionResultUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/get", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(subSessionResultUrl),
+                                                    SubSessionResultContext.Default.SubSessionResult,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -408,13 +436,17 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/lap_chart_data", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["subsession_id"] = subSessionId.ToString(CultureInfo.InvariantCulture),
             ["simsession_number"] = simSessionNumber.ToString(CultureInfo.InvariantCulture),
-        });
+        };
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionLapsHeaderContext.Default.SubsessionLapsHeader, cancellationToken).ConfigureAwait(false);
+        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/lap_chart_data", queryParameters);
+
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl),
+                                                                        SubsessionLapsHeaderContext.Default.SubsessionLapsHeader,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         var sessionLapsList = new List<SubsessionChartLap>();
 
@@ -461,13 +493,17 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/event_log", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["subsession_id"] = subSessionId.ToString(CultureInfo.InvariantCulture),
             ["simsession_number"] = simSessionNumber.ToString(CultureInfo.InvariantCulture),
-        });
+        };
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionEventLogHeaderContext.Default.SubsessionEventLogHeader, cancellationToken).ConfigureAwait(false);
+        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/event_log", queryParameters);
+
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl),
+                                                                        SubsessionEventLogHeaderContext.Default.SubsessionEventLogHeader,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         var sessionLapsList = new List<SubsessionEventLogItem>();
 
@@ -514,8 +550,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var seriesUrl = new Uri("https://members-ng.iracing.com/data/series/get");
-        return await CreateResponseViaInfoLinkAsync(seriesUrl, SeriesDetailArrayContext.Default.SeriesDetailArray, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/series/get"),
+                                                    SeriesDetailArrayContext.Default.SeriesDetailArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -526,8 +563,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var seriesUrl = new Uri("https://members-ng.iracing.com/data/series/assets");
-        return await CreateResponseViaInfoLinkAsync(seriesUrl, SeriesAssetReadOnlyDictionaryContext.Default.IReadOnlyDictionaryStringSeriesAsset, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/series/assets"),
+                                                    SeriesAssetReadOnlyDictionaryContext.Default.IReadOnlyDictionaryStringSeriesAsset,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -538,14 +576,18 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/lap_data", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["subsession_id"] = subSessionId.ToString(CultureInfo.InvariantCulture),
             ["simsession_number"] = simSessionNumber.ToString(CultureInfo.InvariantCulture),
             ["cust_id"] = customerId.ToString(CultureInfo.InvariantCulture),
-        });
+        };
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionLapsHeaderContext.Default.SubsessionLapsHeader, cancellationToken).ConfigureAwait(false);
+        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/lap_data", queryParameters);
+
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl),
+                                                                        SubsessionLapsHeaderContext.Default.SubsessionLapsHeader,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         var sessionLapsList = new List<SubsessionLap>();
 
@@ -592,14 +634,18 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/lap_data", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["subsession_id"] = subSessionId.ToString(CultureInfo.InvariantCulture),
             ["simsession_number"] = simSessionNumber.ToString(CultureInfo.InvariantCulture),
             ["team_id"] = teamId.ToString(CultureInfo.InvariantCulture),
-        });
+        };
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SubsessionLapsHeaderContext.Default.SubsessionLapsHeader, cancellationToken).ConfigureAwait(false);
+        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/lap_data", queryParameters);
+
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl),
+                                                                        SubsessionLapsHeaderContext.Default.SubsessionLapsHeader,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         var sessionLapsList = new List<SubsessionLap>();
 
@@ -646,13 +692,17 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var memberDivisionUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/member_division", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
             ["event_type"] = eventType.ToString("D"),
-        });
+        };
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(memberDivisionUrl), MemberDivisionContext.Default.MemberDivision, cancellationToken).ConfigureAwait(false);
+        var memberDivisionUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/member_division", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberDivisionUrl),
+                                                    MemberDivisionContext.Default.MemberDivision,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -663,7 +713,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/stats/member_yearly"), MemberYearlyStatisticsContext.Default.MemberYearlyStatistics, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/stats/member_yearly"),
+                                                    MemberYearlyStatisticsContext.Default.MemberYearlyStatistics,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -676,7 +728,6 @@ internal class DataClient : IDataClient
 
         var parameters = new Dictionary<string, string>
         {
-            //["cust_id"] = customerId.ToString(CultureInfo.InvariantCulture),
             ["category_id"] = categoryId.ToString(CultureInfo.InvariantCulture),
             ["chart_type"] = chartType.ToString("D"),
         };
@@ -699,29 +750,31 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryParams = new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["car_id"] = carId.ToString(CultureInfo.InvariantCulture),
             ["track_id"] = trackId.ToString(CultureInfo.InvariantCulture),
         };
 
-        if (seasonYear is int seasonYearValue)
+        if (seasonYear is not null)
         {
-            queryParams.Add("season_year", seasonYearValue.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("season_year", seasonYear.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        if (seasonQuarter is int seasonQuarterValue)
+        if (seasonQuarter is not null)
         {
             if (seasonYear is null)
             {
                 throw new ArgumentException($"Must supply a value for \"{nameof(seasonYear)}\" to use \"{nameof(seasonQuarter)}\".", nameof(seasonQuarter));
             }
-            queryParams.Add("season_quarter", seasonQuarterValue.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("season_quarter", seasonQuarter.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/world_records", queryParams);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/world_records", queryParameters);
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), WorldRecordsHeaderContext.Default.WorldRecordsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(queryUrl),
+                                                                        WorldRecordsHeaderContext.Default.WorldRecordsHeader,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         var entries = new List<WorldRecordEntry>();
 
@@ -768,14 +821,16 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryUrl = "https://members-ng.iracing.com/data/team/get";
-
-        queryUrl = QueryHelpers.AddQueryString(queryUrl, new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["team_id"] = teamId.ToString(CultureInfo.InvariantCulture),
-        });
+        };
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), TeamInfoContext.Default.TeamInfo, cancellationToken).ConfigureAwait(false);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/team/get", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl),
+                                                    TeamInfoContext.Default.TeamInfo,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -786,7 +841,7 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryParams = new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
             ["car_class_id"] = carClassId.ToString(CultureInfo.InvariantCulture),
@@ -794,29 +849,31 @@ internal class DataClient : IDataClient
             ["club_id"] = clubId.ToString(CultureInfo.InvariantCulture),
         };
 
-        if (division is int divisionValue)
+        if (division is not null)
         {
-            queryParams.Add("division", divisionValue.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("division", division.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_driver_standings", queryParams);
+        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_driver_standings", queryParameters);
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonDriverStandingsHeaderContext.Default.SeasonDriverStandingsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl),
+                                                                        SeasonDriverStandingsHeaderContext.Default.SeasonDriverStandingsHeader,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         var sessionLapsList = new List<SeasonDriverStanding>();
 
-        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo is ChunkInfo { NumberOfChunks: > 0 } chunkInfo)
         {
-            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(chunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in chunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, chunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -848,7 +905,7 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryParams = new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
             ["car_class_id"] = carClassId.ToString(CultureInfo.InvariantCulture),
@@ -856,29 +913,31 @@ internal class DataClient : IDataClient
             ["club_id"] = clubId.ToString(CultureInfo.InvariantCulture),
         };
 
-        if (division is int divisionValue)
+        if (division is not null)
         {
-            queryParams.Add("division", divisionValue.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("division", division.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        var qualifyResultsUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_qualify_results", queryParams);
+        var qualifyResultsUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_qualify_results", queryParameters);
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(qualifyResultsUrl), SeasonQualifyResultsHeaderContext.Default.SeasonQualifyResultsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(qualifyResultsUrl),
+                                                                        SeasonQualifyResultsHeaderContext.Default.SeasonQualifyResultsHeader,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         var seasonQualifyResults = new List<SeasonQualifyResult>();
 
-        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo is ChunkInfo { NumberOfChunks: > 0 } chunkInfo)
         {
-            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(chunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in chunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, chunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -910,7 +969,7 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var resultsStatsSearchParams = new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
             ["car_class_id"] = carClassId.ToString(CultureInfo.InvariantCulture),
@@ -918,29 +977,31 @@ internal class DataClient : IDataClient
             ["club_id"] = clubId.ToString(CultureInfo.InvariantCulture),
         };
 
-        if (division is int divisionValue)
+        if (division is not null)
         {
-            resultsStatsSearchParams.Add("division", divisionValue.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("division", division.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_tt_results", resultsStatsSearchParams);
+        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_tt_results", queryParameters);
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonTimeTrialResultsHeaderContext.Default.SeasonTimeTrialResultsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl),
+                                                                        SeasonTimeTrialResultsHeaderContext.Default.SeasonTimeTrialResultsHeader,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         var seasonTimeTrialResults = new List<SeasonTimeTrialResult>();
 
-        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo is ChunkInfo { NumberOfChunks: > 0 } chunkInfo)
         {
-            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(chunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in chunkInfo.ChunkFileNames.Select<string, (string fn, int i)>((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, chunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -972,7 +1033,7 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var resultsStatsSearchParams = new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
             ["car_class_id"] = carClassId.ToString(CultureInfo.InvariantCulture),
@@ -980,28 +1041,30 @@ internal class DataClient : IDataClient
             ["club_id"] = clubId.ToString(CultureInfo.InvariantCulture),
         };
 
-        if (division is int divisionValue)
+        if (division is not null)
         {
-            resultsStatsSearchParams.Add("division", divisionValue.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("division", division.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_tt_standings", resultsStatsSearchParams);
+        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_tt_standings", queryParameters);
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonTimeTrialStandingsHeaderContext.Default.SeasonTimeTrialStandingsHeader, cancellationToken).ConfigureAwait(false);
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl),
+                                                                        SeasonTimeTrialStandingsHeaderContext.Default.SeasonTimeTrialStandingsHeader,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         var seasonTimeTrialStandings = new List<SeasonTimeTrialStanding>();
 
-        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo is ChunkInfo { NumberOfChunks: > 0 } chunkInfo)
         {
-            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
-            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
+            var baseChunkUrl = new Uri(chunkInfo.BaseDownloadUrl);
+            foreach (var (chunkFileName, index) in chunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, chunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -1033,29 +1096,33 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_team_standings", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
             ["car_class_id"] = carClassId.ToString(CultureInfo.InvariantCulture),
             ["race_week_num"] = raceWeekNumber.ToString(CultureInfo.InvariantCulture),
-        });
+        };
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl), SeasonTeamStandingsHeaderContext.Default.SeasonTeamStandingsHeader, cancellationToken).ConfigureAwait(false);
+        var subSessionLapChartUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/season_team_standings", queryParameters);
+
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(subSessionLapChartUrl),
+                                                                        SeasonTeamStandingsHeaderContext.Default.SeasonTeamStandingsHeader,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         var seasonTeamStandings = new List<SeasonTeamStanding>();
 
-        if (intermediateResponse.Data.ChunkInfo.NumberOfChunks > 0)
+        if (intermediateResponse.Data.ChunkInfo is ChunkInfo { NumberOfChunks: > 0 } chunkInfo)
         {
-            var baseChunkUrl = new Uri(intermediateResponse.Data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(chunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in intermediateResponse.Data.ChunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in chunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, intermediateResponse.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, chunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -1087,14 +1154,18 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var seasonResultsUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/season_results", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
             ["event_type"] = eventType.ToString("D"),
             ["race_week_num"] = raceWeekNumber.ToString(CultureInfo.InvariantCulture),
-        });
+        };
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(seasonResultsUrl), SeasonResultsContext.Default.SeasonResults, cancellationToken).ConfigureAwait(false);
+        var seasonResultsUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/season_results", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(seasonResultsUrl),
+                                                    SeasonResultsContext.Default.SeasonResults,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1105,12 +1176,16 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var seasonSeriesUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/series/seasons", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["include_series"] = includeSeries ? "true" : "false",
-        });
+        };
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(seasonSeriesUrl), SeasonSeriesArrayContext.Default.SeasonSeriesArray, cancellationToken).ConfigureAwait(false);
+        var seasonSeriesUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/series/seasons", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(seasonSeriesUrl),
+                                                    SeasonSeriesArrayContext.Default.SeasonSeriesArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1121,7 +1196,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/series/stats_series"), StatisticsSeriesArrayContext.Default.StatisticsSeriesArray, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/series/stats_series"),
+                                                    StatisticsSeriesArrayContext.Default.StatisticsSeriesArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1132,25 +1209,23 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var careerStatisticsUrl = "https://members-ng.iracing.com/data/stats/member_bests";
-        var queryParams = new Dictionary<string, string>();
+        var queryParameters = new Dictionary<string, string>();
 
         if (customerId is not null)
         {
-            queryParams.Add("cust_id", customerId.Value.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("cust_id", customerId.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         if (carId is not null)
         {
-            queryParams.Add("car_id", carId.Value.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("car_id", carId.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        if (queryParams.Count > 0)
-        {
-            careerStatisticsUrl = QueryHelpers.AddQueryString(careerStatisticsUrl, queryParams);
-        }
+        var careerStatisticsUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/member_bests", queryParameters);
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(careerStatisticsUrl), MemberBestsContext.Default.MemberBests, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri(careerStatisticsUrl),
+                                                    MemberBestsContext.Default.MemberBests,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1161,15 +1236,18 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var careerStatisticsUrl = "https://members-ng.iracing.com/data/stats/member_career";
+        var queryParameters = new Dictionary<string, string>();
+
         if (customerId is not null)
         {
-            careerStatisticsUrl = QueryHelpers.AddQueryString(careerStatisticsUrl, new Dictionary<string, string>
-            {
-                ["cust_id"] = customerId.Value.ToString(CultureInfo.InvariantCulture),
-            });
+            queryParameters.Add("cust_id", customerId.Value.ToString(CultureInfo.InvariantCulture));
         }
-        return await CreateResponseViaInfoLinkAsync(new Uri(careerStatisticsUrl), MemberCareerContext.Default.MemberCareer, cancellationToken).ConfigureAwait(false);
+
+        var careerStatisticsUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/member_career", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(careerStatisticsUrl),
+                                                    MemberCareerContext.Default.MemberCareer,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1180,16 +1258,18 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var memberRecentRacesUrl = "https://members-ng.iracing.com/data/stats/member_recent_races";
+        var queryParameters = new Dictionary<string, string>();
+
         if (customerId is not null)
         {
-            memberRecentRacesUrl = QueryHelpers.AddQueryString(memberRecentRacesUrl, new Dictionary<string, string>
-            {
-                ["cust_id"] = customerId.Value.ToString(CultureInfo.InvariantCulture),
-            });
+            queryParameters.Add("cust_id", customerId.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(memberRecentRacesUrl), MemberRecentRacesContext.Default.MemberRecentRaces, cancellationToken).ConfigureAwait(false);
+        var memberRecentRacesUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/member_recent_races", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberRecentRacesUrl),
+                                                    MemberRecentRacesContext.Default.MemberRecentRaces,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1200,15 +1280,18 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var memberSummaryUrl = "https://members-ng.iracing.com/data/stats/member_summary";
+        var queryParameters = new Dictionary<string, string>();
+
         if (customerId is not null)
         {
-            memberSummaryUrl = QueryHelpers.AddQueryString(memberSummaryUrl, new Dictionary<string, string>
-            {
-                ["cust_id"] = customerId.Value.ToString(CultureInfo.InvariantCulture),
-            });
+            queryParameters.Add("cust_id", customerId.Value.ToString(CultureInfo.InvariantCulture));
         }
-        return await CreateResponseViaInfoLinkAsync(new Uri(memberSummaryUrl), MemberSummaryContext.Default.MemberSummary, cancellationToken).ConfigureAwait(false);
+
+        var memberSummaryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/member_summary", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberSummaryUrl),
+                                                    MemberSummaryContext.Default.MemberSummary,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1219,9 +1302,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var getTrackUrl = "https://members-ng.iracing.com/data/track/assets";
-
-        return await CreateResponseViaInfoLinkAsync(new Uri(getTrackUrl), TrackAssetsArrayContext.Default.IReadOnlyDictionaryStringTrackAssets, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/track/assets"),
+                                                    TrackAssetsArrayContext.Default.IReadOnlyDictionaryStringTrackAssets,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1232,9 +1315,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var getTrackUrl = "https://members-ng.iracing.com/data/track/get";
-
-        return await CreateResponseViaInfoLinkAsync(new Uri(getTrackUrl), TrackArrayContext.Default.TrackArray, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/track/get"),
+                                                    TrackArrayContext.Default.TrackArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1274,37 +1357,37 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryParams = new Dictionary<string, string>();
-        queryParams.AddParameterIfNotNull(() => searchParameters.StartRangeBegin);
-        queryParams.AddParameterIfNotNull(() => searchParameters.StartRangeEnd);
-        queryParams.AddParameterIfNotNull(() => searchParameters.FinishRangeBegin);
-        queryParams.AddParameterIfNotNull(() => searchParameters.FinishRangeEnd);
-        queryParams.AddParameterIfNotNull(() => searchParameters.ParticipantCustomerId);
-        queryParams.AddParameterIfNotNull(() => searchParameters.HostCustomerId);
-        queryParams.AddParameterIfNotNull(() => searchParameters.SessionName);
-        queryParams.AddParameterIfNotNull(() => searchParameters.LeagueId);
-        queryParams.AddParameterIfNotNull(() => searchParameters.LeagueSeasonId);
-        queryParams.AddParameterIfNotNull(() => searchParameters.CarId);
-        queryParams.AddParameterIfNotNull(() => searchParameters.TrackId);
-        queryParams.AddParameterIfNotNull(() => searchParameters.CategoryIds);
+        var queryParameters = new Dictionary<string, string>();
+        queryParameters.AddParameterIfNotNull(() => searchParameters.StartRangeBegin);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.StartRangeEnd);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.FinishRangeBegin);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.FinishRangeEnd);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.ParticipantCustomerId);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.HostCustomerId);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.SessionName);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.LeagueId);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.LeagueSeasonId);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.CarId);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.TrackId);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.CategoryIds);
 
-        var searchHostedUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/search_hosted", queryParams);
+        var searchHostedUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/search_hosted", queryParameters);
 
         (var headers, var header) = await GetResponseAsync(new Uri(searchHostedUrl), HostedResultsHeaderContext.Default.HostedResultsHeader, cancellationToken).ConfigureAwait(false);
 
         var searchResults = new List<HostedResultItem>();
-        if (header.Data.ChunkInfo.NumberOfChunks > 0)
+        if (header.Data.ChunkInfo is ChunkInfo { NumberOfChunks: > 0 } chunkInfo)
         {
-            var baseChunkUrl = new Uri(header.Data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(chunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in header.Data.ChunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in chunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, header.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, chunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -1360,36 +1443,36 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryParams = new Dictionary<string, string>();
-        queryParams.AddParameterIfNotNull(() => searchParameters.StartRangeBegin);
-        queryParams.AddParameterIfNotNull(() => searchParameters.StartRangeEnd);
-        queryParams.AddParameterIfNotNull(() => searchParameters.FinishRangeBegin);
-        queryParams.AddParameterIfNotNull(() => searchParameters.FinishRangeEnd);
-        queryParams.AddParameterIfNotNull(() => searchParameters.ParticipantCustomerId);
-        queryParams.AddParameterIfNotNull(() => searchParameters.SeriesId);
-        queryParams.AddParameterIfNotNull(() => searchParameters.RaceWeekIndex);
-        queryParams.AddParameterIfNotNull(() => searchParameters.OfficialOnly);
-        queryParams.AddParameterIfNotNull(() => searchParameters.EventTypes);
-        queryParams.AddParameterIfNotNull(() => searchParameters.CategoryIds);
+        var queryParameters = new Dictionary<string, string>();
+        queryParameters.AddParameterIfNotNull(() => searchParameters.StartRangeBegin);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.StartRangeEnd);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.FinishRangeBegin);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.FinishRangeEnd);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.ParticipantCustomerId);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.SeriesId);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.RaceWeekIndex);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.OfficialOnly);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.EventTypes);
+        queryParameters.AddParameterIfNotNull(() => searchParameters.CategoryIds);
 
-        var searchHostedUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/search_series", queryParams);
+        var searchHostedUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/results/search_series", queryParameters);
 
         (var headers, var header) = await GetResponseAsync(new Uri(searchHostedUrl), OfficialSearchResultHeaderContext.Default.OfficialSearchResultHeader, cancellationToken).ConfigureAwait(false);
 
         var searchResults = new List<OfficialSearchResultItem>();
 
-        if (header.Data.ChunkInfo.NumberOfChunks > 0)
+        if (header.Data.ChunkInfo is ChunkInfo { NumberOfChunks: > 0 } chunkInfo)
         {
-            var baseChunkUrl = new Uri(header.Data.ChunkInfo.BaseDownloadUrl);
+            var baseChunkUrl = new Uri(chunkInfo.BaseDownloadUrl);
 
-            foreach (var (chunkFileName, index) in header.Data.ChunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
+            foreach (var (chunkFileName, index) in chunkInfo.ChunkFileNames.Select((fn, i) => (fn, i)))
             {
                 var chunkUrl = new Uri(baseChunkUrl, chunkFileName);
 
                 var chunkResponse = await httpClient.GetAsync(chunkUrl, cancellationToken).ConfigureAwait(false);
                 if (!chunkResponse.IsSuccessStatusCode)
                 {
-                    logger.FailedToRetrieveChunkError(index, header.Data.ChunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
+                    logger.FailedToRetrieveChunkError(index, chunkInfo.NumberOfChunks, chunkResponse.StatusCode, chunkResponse.ReasonPhrase);
                     continue;
                 }
 
@@ -1469,7 +1552,9 @@ internal class DataClient : IDataClient
 
         var searchLeagueDirectoryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/directory", queryParameters);
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(searchLeagueDirectoryUrl), LeagueDirectoryResultPageContext.Default.LeagueDirectoryResultPage, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri(searchLeagueDirectoryUrl),
+                                                    LeagueDirectoryResultPageContext.Default.LeagueDirectoryResultPage,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1480,28 +1565,32 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var memberSummaryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/season/list", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["season_year"] = seasonYear.ToString(CultureInfo.InvariantCulture),
             ["season_quarter"] = seasonQuarter.ToString(CultureInfo.InvariantCulture),
-        });
+        };
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(memberSummaryUrl), ListOfSeasonsContext.Default.ListOfSeasons, cancellationToken).ConfigureAwait(false);
+        var memberSummaryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/season/list", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(memberSummaryUrl),
+                                                    ListOfSeasonsContext.Default.ListOfSeasons,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
-    private Exception? ValidateSearchDateRange(DateTime? rangeBegin, DateTime? rangeEnd, string paramName, string rangeBeginFieldName, string rangeEndFieldName)
+    private Exception? ValidateSearchDateRange(DateTime? rangeBegin, DateTime? rangeEnd, string parameterName, string rangeBeginFieldName, string rangeEndFieldName)
     {
         if (rangeBegin is not null)
         {
             if (rangeBegin.Value > GetDateTimeUtcNow())
             {
-                return new ArgumentOutOfRangeException(paramName, $"Value for \"{rangeBeginFieldName}\" cannot be in the future.");
+                return new ArgumentOutOfRangeException(parameterName, $"Value for \"{rangeBeginFieldName}\" cannot be in the future.");
             }
 
             if (rangeEnd is null
                 && (Math.Abs(GetDateTimeUtcNow().Subtract(rangeBegin.Value).TotalDays) > 90))
             {
-                return new ArgumentOutOfRangeException(paramName, $"Must supply value for \"{rangeEndFieldName}\" if \"{rangeBeginFieldName}\" is more than 90 days in the past.");
+                return new ArgumentOutOfRangeException(parameterName, $"Must supply value for \"{rangeEndFieldName}\" if \"{rangeBeginFieldName}\" is more than 90 days in the past.");
             }
         }
 
@@ -1511,17 +1600,17 @@ internal class DataClient : IDataClient
             {
                 if (rangeBegin >= rangeEnd)
                 {
-                    return new ArgumentOutOfRangeException(paramName, $"Value for \"{rangeBeginFieldName}\" cannot be after \"{rangeEndFieldName}\".");
+                    return new ArgumentOutOfRangeException(parameterName, $"Value for \"{rangeBeginFieldName}\" cannot be after \"{rangeEndFieldName}\".");
                 }
 
                 if (Math.Abs(rangeEnd.Value.Subtract(rangeBegin.Value).TotalDays) > 90)
                 {
-                    return new ArgumentOutOfRangeException(paramName, $"Value for \"{rangeEndFieldName}\" cannot be more than 90 days after \"{rangeBeginFieldName}\".");
+                    return new ArgumentOutOfRangeException(parameterName, $"Value for \"{rangeEndFieldName}\" cannot be more than 90 days after \"{rangeBeginFieldName}\".");
                 }
             }
             else
             {
-                return new ArgumentException($"Must supply value for \"{rangeBeginFieldName}\" if \"{rangeEndFieldName}\" is specified.", paramName);
+                return new ArgumentException($"Must supply value for \"{rangeBeginFieldName}\" if \"{rangeEndFieldName}\" is specified.", parameterName);
             }
         }
 
@@ -1759,18 +1848,21 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryString = new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["include_league"] = includeLeague ? "1" : "0"
         };
 
-        if (customerId?.ToString(CultureInfo.InvariantCulture) is string customerIdValue)
+        if (customerId is not null)
         {
-            queryString.Add("cust_id", customerIdValue);
+            queryParameters.Add("cust_id", customerId.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        var getMembershipUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/membership", queryString);
-        return await CreateResponseViaInfoLinkAsync(new Uri(getMembershipUrl), LeagueMembershipArrayContext.Default.LeagueMembershipArray, cancellationToken).ConfigureAwait(false);
+        var getMembershipUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/membership", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(getMembershipUrl),
+                                                    LeagueMembershipArrayContext.Default.LeagueMembershipArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1781,13 +1873,17 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var getLeagueSeasons = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/seasons", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["league_id"] = leagueId.ToString(CultureInfo.InvariantCulture),
             ["retired"] = includeRetired ? "1" : "0"
-        });
+        };
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(getLeagueSeasons), LeagueSeasonsContext.Default.LeagueSeasons, cancellationToken).ConfigureAwait(false);
+        var getLeagueSeasons = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/seasons", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(getLeagueSeasons),
+                                                    LeagueSeasonsContext.Default.LeagueSeasons,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1798,28 +1894,26 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var raceGuideUrl = "https://members-ng.iracing.com/data/season/race_guide";
+        var queryParameters = new Dictionary<string, string>();
 
-        var queryParams = new Dictionary<string, string>();
         if (from is not null)
         {
             var fromUtc = from.Value.UtcDateTime.ToString("yyyy-MM-dd\\THH:mm\\Z", CultureInfo.InvariantCulture);
-            queryParams.Add("from", fromUtc);
+            queryParameters.Add("from", fromUtc);
         }
 
         if (includeEndAfterFrom is not null)
         {
 #pragma warning disable CA1308 // Normalize strings to uppercase - This value needs to be lowercase for API compatibility.
-            queryParams.Add("include_end_after_from", includeEndAfterFrom.Value.ToString().ToLowerInvariant());
+            queryParameters.Add("include_end_after_from", includeEndAfterFrom.Value.ToString().ToLowerInvariant());
 #pragma warning restore CA1308 // Normalize strings to uppercase
         }
 
-        if (queryParams.Count > 0)
-        {
-            raceGuideUrl = QueryHelpers.AddQueryString(raceGuideUrl, queryParams);
-        }
+        var raceGuideUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/season/race_guide", queryParameters);
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(raceGuideUrl), RaceGuideResultsContext.Default.RaceGuideResults, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri(raceGuideUrl),
+                                                    RaceGuideResultsContext.Default.RaceGuideResults,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1830,9 +1924,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var countryUrl = "https://members-ng.iracing.com/data/lookup/countries";
-
-        return await CreateResponseViaInfoLinkAsync(new Uri(countryUrl), CountryArrayContext.Default.CountryArray, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/lookup/countries"),
+                                                    CountryArrayContext.Default.CountryArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1843,9 +1937,9 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var participationCreditsUrl = "https://members-ng.iracing.com/data/member/participation_credits";
-
-        return await CreateResponseViaInfoLinkAsync(new Uri(participationCreditsUrl), ParticipationCreditsArrayContext.Default.ParticipationCreditsArray, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri("https://members-ng.iracing.com/data/member/participation_credits"),
+                                                    ParticipationCreditsArrayContext.Default.ParticipationCreditsArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1856,14 +1950,18 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var getLeagueSeasonSessions = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/season_sessions", new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["league_id"] = leagueId.ToString(CultureInfo.InvariantCulture),
             ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
             ["results_only"] = resultsOnly ? "1" : "0"
-        });
+        };
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(getLeagueSeasonSessions), LeagueSeasonSessionsContext.Default.LeagueSeasonSessions, cancellationToken).ConfigureAwait(false);
+        var getLeagueSeasonSessions = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/season_sessions", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(getLeagueSeasonSessions),
+                                                    LeagueSeasonSessionsContext.Default.LeagueSeasonSessions,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1874,14 +1972,16 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var getPastSeasonsForSeriesUrl = "https://members-ng.iracing.com/data/series/past_seasons";
-
-        getPastSeasonsForSeriesUrl = QueryHelpers.AddQueryString(getPastSeasonsForSeriesUrl, new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["series_id"] = seriesId.ToString(CultureInfo.InvariantCulture),
-        });
+        };
 
-        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(getPastSeasonsForSeriesUrl), PastSeriesResultContext.Default.PastSeriesResult, cancellationToken).ConfigureAwait(false);
+        var getPastSeasonsForSeriesUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/series/past_seasons", queryParameters);
+
+        var intermediateResponse = await CreateResponseViaInfoLinkAsync(new Uri(getPastSeasonsForSeriesUrl),
+                                                                        PastSeriesResultContext.Default.PastSeriesResult,
+                                                                        cancellationToken).ConfigureAwait(false);
 
         return new DataResponse<PastSeriesDetail>
         {
@@ -1901,9 +2001,7 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryUrl = "https://members-ng.iracing.com/data/league/season_standings";
-
-        var queryParams = new Dictionary<string, string>
+        var queryParameters = new Dictionary<string, string>
         {
             ["league_id"] = leagueId.ToString(CultureInfo.InvariantCulture),
             ["season_id"] = seasonId.ToString(CultureInfo.InvariantCulture),
@@ -1911,17 +2009,19 @@ internal class DataClient : IDataClient
 
         if (carClassId is not null)
         {
-            queryParams.Add("car_class_id", carClassId.Value.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("car_class_id", carClassId.Value.ToString(CultureInfo.InvariantCulture));
         }
 
         if (carId is not null)
         {
-            queryParams.Add("car_id", carId.Value.ToString(CultureInfo.InvariantCulture));
+            queryParameters.Add("car_id", carId.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParams);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/league/season_standings", queryParameters);
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), SeasonStandingsContext.Default.SeasonStandings, cancellationToken).ConfigureAwait(false);
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl),
+                                                    SeasonStandingsContext.Default.SeasonStandings,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1964,13 +2064,14 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryUrl = "https://members-ng.iracing.com/data/time_attack/member_season_results";
-
         var queryParameters = new Dictionary<string, string>();
         queryParameters.AddParameterIfNotNull("ta_comp_season_id", competitionSeasonId);
-        queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParameters);
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), TimeAttackMemberSeasonResultArrayContext.Default.TimeAttackMemberSeasonResultArray, cancellationToken).ConfigureAwait(false);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/time_attack/member_season_results", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl),
+                                                    TimeAttackMemberSeasonResultArrayContext.Default.TimeAttackMemberSeasonResultArray,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1981,15 +2082,16 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryUrl = "https://members-ng.iracing.com/data/stats/member_recap";
-
         var queryParameters = new Dictionary<string, string>();
         queryParameters.AddParameterIfNotNull("cust_id", customerId);
         queryParameters.AddParameterIfNotNull("year", seasonYear);
         queryParameters.AddParameterIfNotNull("season", seasonQuarter);
-        queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParameters);
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), MemberRecapContext.Default.MemberRecap, cancellationToken).ConfigureAwait(false);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/stats/member_recap", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl),
+                                                    MemberRecapContext.Default.MemberRecap,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -2000,12 +2102,13 @@ internal class DataClient : IDataClient
             await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var queryUrl = "https://members-ng.iracing.com/data/season/spectator_subsessionids";
-
         var queryParameters = new Dictionary<string, string>();
         queryParameters.AddParameterIfNotNull("event_types", eventTypes);
-        queryUrl = QueryHelpers.AddQueryString(queryUrl, queryParameters);
 
-        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl), SpectatorSubsessionIdsContext.Default.SpectatorSubsessionIds, cancellationToken).ConfigureAwait(false);
+        var queryUrl = QueryHelpers.AddQueryString("https://members-ng.iracing.com/data/season/spectator_subsessionids", queryParameters);
+
+        return await CreateResponseViaInfoLinkAsync(new Uri(queryUrl),
+                                                    SpectatorSubsessionIdsContext.Default.SpectatorSubsessionIds,
+                                                    cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Aydsko.iRacingData/DataClient.cs
+++ b/src/Aydsko.iRacingData/DataClient.cs
@@ -138,13 +138,12 @@ internal class DataClient : IDataClient
         }
 
         var constantsDivisionsUrl = new Uri("https://members-ng.iracing.com/data/constants/categories");
-        var constantsDivisionsResponse = await httpClient.GetAsync(constantsDivisionsUrl, cancellationToken).ConfigureAwait(false);
+        var constantsDivisionsResponse = await httpClient.GetAsync(constantsDivisionsUrl, cancellationToken)
+                                                         .ConfigureAwait(false);
 
-        var data = await constantsDivisionsResponse.Content.ReadFromJsonAsync(CategoryArrayContext.Default.CategoryArray, cancellationToken).ConfigureAwait(false);
-        if (data is null)
-        {
-            throw new iRacingDataClientException("Data not found.");
-        }
+        var data = await constantsDivisionsResponse.Content.ReadFromJsonAsync(CategoryArrayContext.Default.CategoryArray, cancellationToken)
+                                                           .ConfigureAwait(false)
+                                                           ?? throw new iRacingDataClientException("Data not found.");
 
         return BuildDataResponse(constantsDivisionsResponse.Headers, data, logger)!;
     }
@@ -160,11 +159,9 @@ internal class DataClient : IDataClient
         var constantsDivisionsUrl = new Uri("https://members-ng.iracing.com/data/constants/event_types");
         var constantsDivisionsResponse = await httpClient.GetAsync(constantsDivisionsUrl, cancellationToken).ConfigureAwait(false);
 
-        var data = await constantsDivisionsResponse.Content.ReadFromJsonAsync(EventTypeArrayContext.Default.EventTypeArray, cancellationToken).ConfigureAwait(false);
-        if (data is null)
-        {
-            throw new iRacingDataClientException("Data not found.");
-        }
+        var data = await constantsDivisionsResponse.Content.ReadFromJsonAsync(EventTypeArrayContext.Default.EventTypeArray, cancellationToken)
+                                                           .ConfigureAwait(false)
+                                                           ?? throw new iRacingDataClientException("Data not found.");
 
         return BuildDataResponse(constantsDivisionsResponse.Headers, data, logger)!;
     }
@@ -1570,7 +1567,7 @@ internal class DataClient : IDataClient
 
     private const string RateLimitExceededContent = "Rate limit exceeded";
 
-    protected virtual async Task<(HttpResponseHeaders Headers, TData Data, DateTimeOffset? Expires)> CreateResponseViaInfoLinkAsync<TData>(Uri infoLinkUri, JsonTypeInfo<TData> jsonTypeInfo, CancellationToken cancellationToken)
+    async protected virtual Task<(HttpResponseHeaders Headers, TData Data, DateTimeOffset? Expires)> CreateResponseViaInfoLinkAsync<TData>(Uri infoLinkUri, JsonTypeInfo<TData> jsonTypeInfo, CancellationToken cancellationToken)
     {
         var infoLinkResponse = await httpClient.GetAsync(infoLinkUri, cancellationToken).ConfigureAwait(false);
 
@@ -1615,11 +1612,8 @@ internal class DataClient : IDataClient
         }
 
         var data = await response.Content.ReadFromJsonAsync(jsonTypeInfo, cancellationToken: cancellationToken)
-                                         .ConfigureAwait(false);
-        if (data is null)
-        {
-            throw new iRacingDataClientException("Data not found.");
-        }
+                                         .ConfigureAwait(false)
+                                         ?? throw new iRacingDataClientException("Data not found.");
 
         return (response.Headers, data);
     }

--- a/src/Aydsko.iRacingData/LoggingExtensions.cs
+++ b/src/Aydsko.iRacingData/LoggingExtensions.cs
@@ -12,22 +12,29 @@ public static class LoggingExtensions
     private const int EventIdErrorResponseUnknownTrace = 3;
     private const int EventIdErrorResponseTrace = 4;
     private const int EventIdFailedToRetrieveChunkError = 5;
+    private const int EventIdTraceCacheHitOrMiss = 6;
 
     private static readonly Action<ILogger, string, Exception?> loginSuccessful = LoggerMessage.Define<string>(LogLevel.Information,
                                                                                                                new EventId(EventIdLoginSuccessful, nameof(LoginSuccessful)),
                                                                                                                "Authenticated successfully as {UserEmail}");
+
     private static readonly Action<ILogger, int?, int?, DateTimeOffset?, Exception?> rateLimitsUpdated = LoggerMessage.Define<int?, int?, DateTimeOffset?>(LogLevel.Debug,
                                                                                                                                                            new EventId(EventIdRateLimitsUpdated, nameof(RateLimitsUpdated)),
                                                                                                                                                            "Currently have {RateLimitRemaining} calls left from {RateLimitTotal} resetting at {RateLimitResetInstant}");
+
     private static readonly Action<ILogger, Exception?> errorResponseUnknownTrace = LoggerMessage.Define(LogLevel.Trace,
                                                                                                          new EventId(EventIdErrorResponseUnknownTrace, nameof(ErrorResponseUnknown)),
                                                                                                          "Error response was unknown so throwing a standard HTTP error");
+
     private static readonly Action<ILogger, string?, Exception?> errorResponse = LoggerMessage.Define<string?>(LogLevel.Trace,
                                                                                                                new EventId(EventIdErrorResponseTrace, nameof(ErrorResponse)),
                                                                                                                "Error response from iRacing API: {ErrorDescription}");
+
     private static readonly Action<ILogger, int?, int?, HttpStatusCode?, string?, Exception?> failedToRetrieveChunkError = LoggerMessage.Define<int?, int?, HttpStatusCode?, string?>(LogLevel.Error,
                                                                                                                                                                                       new EventId(EventIdFailedToRetrieveChunkError, nameof(FailedToRetrieveChunkError)),
                                                                                                                                                                                       "Failed to retrieve chunk index {ChunkIndex} of {ChunkTotalCount} due to status code {HttpStatusCode} reason {HttpStatusReasonPhrase}");
+
+    private static readonly Action<ILogger, Uri, bool, Exception?> traceCacheHitOrMiss = LoggerMessage.Define<Uri, bool>(LogLevel.Trace, EventIdTraceCacheHitOrMiss, "Cache status for {Url} is {HitStatus}");
 
     public static void LoginSuccessful(this ILogger logger, string userEmail)
     {
@@ -52,5 +59,10 @@ public static class LoggingExtensions
     public static void FailedToRetrieveChunkError(this ILogger logger, int? chunkIndex, int? chunkTotalCount, HttpStatusCode? httpStatusCode, string? reasonPhrase)
     {
         failedToRetrieveChunkError(logger, chunkIndex, chunkTotalCount, httpStatusCode, reasonPhrase, null);
+    }
+
+    public static void TraceCacheHitOrMiss(this ILogger logger, Uri infoLinkUri, bool isHit)
+    {
+        traceCacheHitOrMiss(logger, infoLinkUri, isHit, null);
     }
 }

--- a/src/Aydsko.iRacingData/ServicesExtensions.cs
+++ b/src/Aydsko.iRacingData/ServicesExtensions.cs
@@ -11,6 +11,26 @@ namespace Aydsko.iRacingData;
 
 public static class ServicesExtensions
 {
+    /// <summary>Add required types for iRacing Data API to the service collection.</summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The service collection for further configuration.</returns>
+    /// <exception cref="ArgumentNullException">One of the arguments is <see langword="null"/>.</exception>
+    public static IServiceCollection AddIRacingDataApi(this IServiceCollection services)
+    {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        services.AddIRacingDataApiInternal(null, false);
+        return services;
+    }
+
+    /// <summary>Add required types for iRacing Data API to the service collection.</summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configureOptions">Action to configure the options for the API client.</param>
+    /// <returns>The service collection for further configuration.</returns>
+    /// <exception cref="ArgumentNullException">One of the arguments is <see langword="null"/>.</exception>
     public static IServiceCollection AddIRacingDataApi(this IServiceCollection services, Action<iRacingDataClientOptions> configureOptions)
     {
         if (services is null)
@@ -27,6 +47,26 @@ public static class ServicesExtensions
         return services;
     }
 
+    /// <summary>Add required types for iRacing Data API with caching enabled to the service collection.</summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The service collection for further configuration.</returns>
+    /// <exception cref="ArgumentNullException">One of the arguments is <see langword="null"/>.</exception>
+    public static IServiceCollection AddIRacingDataApiWithCaching(this IServiceCollection services)
+    {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        services.AddIRacingDataApiInternal(null, true);
+        return services;
+    }
+
+    /// <summary>Add required types for iRacing Data API with caching enabled to the service collection.</summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configureOptions">Action to configure the options for the API client.</param>
+    /// <returns>The service collection for further configuration.</returns>
+    /// <exception cref="ArgumentNullException">One of the arguments is <see langword="null"/>.</exception>
     public static IServiceCollection AddIRacingDataApiWithCaching(this IServiceCollection services, Action<iRacingDataClientOptions> configureOptions)
     {
         if (services is null)
@@ -44,7 +84,7 @@ public static class ServicesExtensions
     }
 
     static internal IHttpClientBuilder AddIRacingDataApiInternal(this IServiceCollection services,
-                                                                 Action<iRacingDataClientOptions> configureOptions,
+                                                                 Action<iRacingDataClientOptions>? configureOptions,
                                                                  bool includeCaching)
     {
         if (services is null)
@@ -52,13 +92,11 @@ public static class ServicesExtensions
             throw new ArgumentNullException(nameof(services));
         }
 
-        configureOptions ??= opt => { };
-
         services.TryAddSingleton(new CookieContainer());
         services.TryAddTransient<TrackScreenshotService>();
 
         var options = new iRacingDataClientOptions();
-        configureOptions(options);
+        configureOptions?.Invoke(options);
         services.AddSingleton(options);
 
         var userAgentValue = CreateUserAgentValue(options);


### PR DESCRIPTION
Initial implementation of caching to address #165.

Right now you need to ensure you've added the memory cache to the services and then call `AddIRacingDataApiWithCaching` to configure the version of the data client with caching enabled.