### PR TITLE
Implement Flags Enum for Lap Events

### DIFF
--- a/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
@@ -574,7 +574,8 @@ public class CapturedResponseValidationTests : MockedHttpTestBase
         Assert.That(lapChartResponse.Data.Laps, Has.Length.EqualTo(417));
         Assert.That(lapChartResponse.Data.Laps, Has.ItemAt(0).Property(nameof(SubsessionChartLap.GroupId)).EqualTo(523780)
                                                    .And.ItemAt(0).Property(nameof(SubsessionChartLap.Name)).EqualTo("Jake Dennis")
-                                                   .And.ItemAt(0).Property(nameof(SubsessionChartLap.LapPosition)).EqualTo(1));
+                                                   .And.ItemAt(0).Property(nameof(SubsessionChartLap.LapPosition)).EqualTo(1)
+                                                   .And.ItemAt(0).Property(nameof(SubsessionLap.Flags)).EqualTo(LapFlags.None));
 
         Assert.That(lapChartResponse.RateLimitRemaining, Is.EqualTo(99));
         Assert.That(lapChartResponse.TotalRateLimit, Is.EqualTo(100));
@@ -617,7 +618,8 @@ public class CapturedResponseValidationTests : MockedHttpTestBase
         Assert.That(lapChartResponse.Data.Laps, Has.Length.EqualTo(16));
         Assert.That(lapChartResponse.Data.Laps, Has.ItemAt(0).Property(nameof(SubsessionLap.GroupId)).EqualTo(341554)
                                                    .And.ItemAt(0).Property(nameof(SubsessionLap.Name)).EqualTo("Adrian Clark")
-                                                   .And.ItemAt(0).Property(nameof(SubsessionLap.Incident)).EqualTo(false));
+                                                   .And.ItemAt(0).Property(nameof(SubsessionLap.Incident)).EqualTo(false)
+                                                   .And.ItemAt(0).Property(nameof(SubsessionLap.Flags)).EqualTo(LapFlags.Invalid | LapFlags.Pitted | LapFlags.Tow));
 
         Assert.That(lapChartResponse.RateLimitRemaining, Is.EqualTo(99));
         Assert.That(lapChartResponse.TotalRateLimit, Is.EqualTo(100));
@@ -652,7 +654,8 @@ public class CapturedResponseValidationTests : MockedHttpTestBase
         Assert.That(lapChartResponse.Data.Laps, Has.Length.EqualTo(500));
         Assert.That(lapChartResponse.Data.Laps, Has.ItemAt(0).Property(nameof(SubsessionLap.GroupId)).EqualTo(-93376)
                                                    .And.ItemAt(0).Property(nameof(SubsessionLap.Name)).EqualTo("Tempest Motorsports Neon")
-                                                   .And.ItemAt(0).Property(nameof(SubsessionLap.Incident)).EqualTo(false));
+                                                   .And.ItemAt(0).Property(nameof(SubsessionLap.Incident)).EqualTo(false)
+                                                   .And.ItemAt(0).Property(nameof(SubsessionLap.Flags)).EqualTo(LapFlags.None));
 
         Assert.That(lapChartResponse.RateLimitRemaining, Is.EqualTo(99));
         Assert.That(lapChartResponse.TotalRateLimit, Is.EqualTo(100));

--- a/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
+++ b/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
@@ -6,7 +6,7 @@
 
     <!-- Package Validation (https://docs.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview) -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.8.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.9.0</PackageValidationBaselineVersion>
     <GenerateCompatibilitySuppressionFile>false</GenerateCompatibilitySuppressionFile>
     <EnableStrictModeForCompatibleFrameworksInPackage>true</EnableStrictModeForCompatibleFrameworksInPackage>
     <EnableStrictModeForCompatibleTfms>true</EnableStrictModeForCompatibleTfms>

--- a/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
+++ b/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
@@ -65,6 +65,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Results.SubsessionLap.set_Flags(System.Int32)</Target>
+    <Left>lib/net6.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Aydsko.iRacingData.Member.MemberAward.get_CustId</Target>
     <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
     <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
@@ -87,6 +94,13 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Aydsko.iRacingData.Member.RecentAwards.set_CustId(System.Int32)</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Results.SubsessionLap.set_Flags(System.Int32)</Target>
     <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
     <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Aydsko.iRacingData/Package Release Notes.txt
+++ b/src/Aydsko.iRacingData/Package Release Notes.txt
@@ -1,4 +1,4 @@
 ﻿Fixes / Changes:
 
- - Cache the results of requests to iRacing. (Issue #165)
- - Fix "CustomerId" properties incorrectly named "CustId" on "MemberAward" and "RecentAwards" classes.
+ - Include Full Bitwise Enum for "SubsessionLap.Flags" (Issue #169)
+ - Original value for the field made available as "SubsessionLap.FlagsRaw"

--- a/src/Aydsko.iRacingData/Results/LapFlags.cs
+++ b/src/Aydsko.iRacingData/Results/LapFlags.cs
@@ -1,0 +1,49 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+namespace Aydsko.iRacingData.Results;
+
+// Source: https://forums.iracing.com/discussion/comment/330994/#Comment_330994
+
+/// <summary>Events which may occur during a lap or characteristics of the lap itself.</summary>
+/// <seealso href="https://forums.iracing.com/discussion/comment/330994/#Comment_330994" />
+[Flags]
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix - This matches the terminology in the API.
+public enum LapFlags
+{
+    /// <summary>No events.</summary>
+    None = 0,
+    /// <summary>Indicates the lap was not valid.</summary>
+    Invalid = 0x0001,
+    /// <summary>The driver entered or exited the pits.</summary>
+    Pitted = 0x0002,
+    /// <summary>The driver left the track surface.</summary>
+    OffTrack = 0x0004,
+    /// <summary>The driver was shown a black flag.</summary>
+    BlackFlag = 0x0008,
+    /// <summary>Driver reset the car.</summary>
+    CarReset = 0x0010,
+    /// <summary>The car made contact.</summary>
+    Contact = 0x0020,
+    /// <summary>The car made contact with another car.</summary>
+    CarContact = 0x0040,
+    /// <summary>The driver lost control of their vehicle.</summary>
+    LostControl = 0x0080,
+    /// <summary>There was an interruption in the lap data.</summary>
+    Discontinuity = 0x0100,
+    /// <summary></summary>
+    InterpolatedCrossing = 0x0200,
+    /// <summary></summary>
+    ClockSmash = 0x0400,
+    /// <summary>The driver towed the car.</summary>
+    Tow = 0x0800,
+    /// <summary>The driver was changed for another one.</summary>
+    DriverChange = 0x1000,
+    /// <summary>It is the initial lap of the race.</summary>
+    FirstLap = 0x2000,
+    /// <summary>The checkered flag was shown on this lap.</summary>
+    Checkered = 0x4000,
+    /// <summary>The driver took an alternate path on the lap, usually indicates a joker lap.</summary>
+    OptionalPath = 0x8000 // i.e. took joker lap
+}
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix

--- a/src/Aydsko.iRacingData/Results/SubsessionLap.cs
+++ b/src/Aydsko.iRacingData/Results/SubsessionLap.cs
@@ -23,7 +23,10 @@ public class SubsessionLap
     public int LapNumber { get; set; }
 
     [JsonPropertyName("flags")]
-    public int Flags { get; set; }
+    public int FlagsRaw { get; set; }
+
+    [JsonIgnore]
+    public LapFlags Flags => (LapFlags)FlagsRaw;
 
     [JsonPropertyName("incident")]
     public bool Incident { get; set; }


### PR DESCRIPTION
The `SubsessionLap.Flags` value is actually a bitwise enumeration. Implement proper support and move the underlying value to the `FlagsRaw` field.

Fixes #169 