### PR TITLE
Make Track Screen Shot URI Generation More Discoverable

### DIFF
--- a/src/Aydsko.iRacingData.IntegrationTests/TestLogger.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/TestLogger.cs
@@ -19,11 +19,7 @@ public class TestLogger<TCategoryName> : ILogger<TCategoryName>
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        if (formatter is null)
-        {
-            throw new ArgumentNullException(nameof(formatter));
-        }
-
+        ArgumentNullException.ThrowIfNull(formatter);
         TestContext.Out.WriteLine($"[{logLevel,-11} | {eventId.Id} | {eventId.Name,-26}] {formatter(state, exception)}");
     }
 }

--- a/src/Aydsko.iRacingData.UnitTests/Converters/JsonConverterTestExtensions.cs
+++ b/src/Aydsko.iRacingData.UnitTests/Converters/JsonConverterTestExtensions.cs
@@ -50,10 +50,14 @@ public static class JsonConverterTestExtensions
 
     public static byte[] WriteUsingConverter<T>(this T input, JsonConverter<T> converter)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(converter);
+#else
         if (converter is null)
         {
             throw new ArgumentNullException(nameof(converter));
         }
+#endif
 
         using var outputStream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(outputStream))

--- a/src/Aydsko.iRacingData.UnitTests/DataClientTrackAssetScreenshotUrisTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/DataClientTrackAssetScreenshotUrisTests.cs
@@ -1,0 +1,110 @@
+﻿namespace Aydsko.iRacingData.UnitTests;
+
+internal sealed class DataClientTrackAssetScreenshotUrisTests : MockedHttpTestBase
+{
+    // NUnit will ensure that "SetUp" runs before each test so these can all be forced to "null".
+    private DataClient? sut = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        BaseSetUp();
+        var dataClient = new DataClient(HttpClient,
+                                        new TestLogger<DataClient>(),
+                                        new iRacingDataClientOptions()
+                                        {
+                                            Username = "test.user@example.com",
+                                            Password = "SuperSecretPassword",
+                                            CurrentDateTimeSource = () => new DateTimeOffset(2022, 04, 05, 0, 0, 0, TimeSpan.Zero)
+                                        },
+                                        new System.Net.CookieContainer());
+
+        // Make use of our captured responses.
+        await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetTracksSuccessfulAsync)).ConfigureAwait(false);
+        await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetTrackAssetsSuccessfulAsync), false).ConfigureAwait(false);
+
+        sut = dataClient;
+    }
+
+    [Test]
+    public async Task GivenHungaroringTrackId_ThenGetTrackAssetScreenshotUrisAsyncReturnsCorrectResults()
+    {
+        const int hungaroringTrackId = 413;
+        var hungaroringResults = await sut!.GetTrackAssetScreenshotUrisAsync(hungaroringTrackId).ConfigureAwait(false);
+
+        Assert.That(hungaroringResults?.Count(), Is.EqualTo(11));
+        Assert.Multiple(() =>
+        {
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/01.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/02.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/03.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/04.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/05.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/06.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/07.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/08.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/09.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/10.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/11.jpg")));
+        });
+    }
+
+    [Test]
+    public async Task GivenSuzukaTrackId_ThenGetScreenshotsByTrackIdReturnsCorrectResults()
+    {
+        const int suzukaTrackId = 168;
+        var suzukaResults = await sut!.GetTrackAssetScreenshotUrisAsync(suzukaTrackId).ConfigureAwait(false);
+
+        Assert.That(suzukaResults?.Count(), Is.EqualTo(4));
+        Assert.Multiple(() =>
+        {
+            Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/01.jpg")));
+            Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/02.jpg")));
+            Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/03.jpg")));
+            Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/04.jpg")));
+        });
+    }
+
+    [Test]
+    public async Task GivenHungaroringTrack_ThenGetTrackAssetScreenshotUrisReturnsCorrectResults()
+    {
+        var hungaroringTrack = (await sut!.GetTracksAsync().ConfigureAwait(false)).Data.Single(t => t.TrackId == 413);
+        var hungaroringTrackAssets = (await sut.GetTrackAssetsAsync().ConfigureAwait(false)).Data["413"];
+
+        var hungaroringResults = sut.GetTrackAssetScreenshotUris(hungaroringTrack, hungaroringTrackAssets);
+
+        Assert.That(hungaroringResults?.Count(), Is.EqualTo(11));
+        Assert.Multiple(() =>
+        {
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/01.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/02.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/03.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/04.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/05.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/06.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/07.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/08.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/09.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/10.jpg")));
+            Assert.That(hungaroringResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/370_screenshots/11.jpg")));
+        });
+    }
+
+    [Test]
+    public async Task GivenSuzukaTrack_ThenGetTrackAssetScreenshotUrisReturnsCorrectResults()
+    {
+        var suzukaTrack = (await sut!.GetTracksAsync().ConfigureAwait(false)).Data.Single(t => t.TrackId == 168);
+        var suzukaTrackAssets = (await sut.GetTrackAssetsAsync().ConfigureAwait(false)).Data["168"];
+
+        var suzukaResults = sut.GetTrackAssetScreenshotUris(suzukaTrack, suzukaTrackAssets);
+
+        Assert.That(suzukaResults?.Count(), Is.EqualTo(4));
+        Assert.Multiple(() =>
+        {
+            Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/01.jpg")));
+            Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/02.jpg")));
+            Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/03.jpg")));
+            Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/04.jpg")));
+        });
+    }
+}

--- a/src/Aydsko.iRacingData.UnitTests/MockedHttpMessageHandler.cs
+++ b/src/Aydsko.iRacingData.UnitTests/MockedHttpMessageHandler.cs
@@ -23,10 +23,14 @@ public class MockedHttpMessageHandler : HttpMessageHandler
 
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(request);
+#else
         if (request is null)
         {
             throw new ArgumentNullException(nameof(request));
         }
+#endif
 
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Aydsko.iRacingData.UnitTests/MockedHttpRequest.cs
+++ b/src/Aydsko.iRacingData.UnitTests/MockedHttpRequest.cs
@@ -13,10 +13,14 @@ public class MockedHttpRequest
 
     public MockedHttpRequest(HttpRequestMessage request)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(request);
+#else
         if (request is null)
         {
             throw new ArgumentNullException(nameof(request));
         }
+#endif
 
         Headers = request.Headers.ToArray();
         if (request.Content != null)

--- a/src/Aydsko.iRacingData.UnitTests/TestLogger.cs
+++ b/src/Aydsko.iRacingData.UnitTests/TestLogger.cs
@@ -23,10 +23,14 @@ public class TestLogger<T> : ILogger<T>
                             Exception? exception,
                             Func<TState, Exception?, string> formatter)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(formatter);
+#else
         if (formatter is null)
         {
             throw new ArgumentNullException(nameof(formatter));
         }
+#endif
 
         var message = formatter(state, exception);
 

--- a/src/Aydsko.iRacingData.UnitTests/TrackScreenshotServiceTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/TrackScreenshotServiceTests.cs
@@ -2,6 +2,7 @@
 
 namespace Aydsko.iRacingData.UnitTests;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 internal sealed class TrackScreenshotServiceTests : MockedHttpTestBase
 {
     // NUnit will ensure that "SetUp" runs before each test so these can all be forced to "null".
@@ -67,3 +68,4 @@ internal sealed class TrackScreenshotServiceTests : MockedHttpTestBase
         });
     }
 }
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
+++ b/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
@@ -274,6 +274,27 @@
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.IDataClient.GetTrackAssetScreenshotUris(Aydsko.iRacingData.Common.Track,Aydsko.iRacingData.Tracks.TrackAssets)</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.IDataClient.GetTrackAssetScreenshotUris(Aydsko.iRacingData.Tracks.Track,Aydsko.iRacingData.Tracks.TrackAssets)</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.IDataClient.GetTrackAssetScreenshotUrisAsync(System.Int32,System.Threading.CancellationToken)</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0009</DiagnosticId>
     <Target>T:Aydsko.iRacingData.Converters.CsvStringConverter</Target>
     <Left>lib/net6.0/Aydsko.iRacingData.dll</Left>

--- a/src/Aydsko.iRacingData/Converters/CsvStringConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/CsvStringConverter.cs
@@ -13,22 +13,23 @@ public sealed class CsvStringConverter : JsonConverter<string[]>
     {
         var csvString = reader.GetString();
 
-        if (csvString is null or { Length: 0 })
-        {
-            return null;
-        }
-
-        return csvString.Split(',');
+        return csvString is null or { Length: 0 }
+            ? null
+            : csvString.Split(',');
     }
 
     public override void Write(Utf8JsonWriter writer,
                                string[] value,
                                JsonSerializerOptions options)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(writer);
+#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
+#endif
 
         writer.WriteStringValue(string.Join(",", value));
     }

--- a/src/Aydsko.iRacingData/Converters/DateOnlyConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/DateOnlyConverter.cs
@@ -28,10 +28,14 @@ public sealed class DateOnlyConverter : JsonConverter<DateOnly>
                                DateOnly value,
                                JsonSerializerOptions options)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(writer);
+#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
+#endif
 
         writer.WriteStringValue(value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
     }

--- a/src/Aydsko.iRacingData/Converters/DateTimeConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/DateTimeConverter.cs
@@ -27,10 +27,14 @@ public sealed class DateTimeConverter : JsonConverter<DateTime>
                                DateTime value,
                                JsonSerializerOptions options)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(writer);
+#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
+#endif
 
         writer.WriteStringValue(value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
     }

--- a/src/Aydsko.iRacingData/Converters/ServiceStatusHistoryItemConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/ServiceStatusHistoryItemConverter.cs
@@ -54,6 +54,10 @@ public sealed class ServiceStatusHistoryItemArrayConverter : JsonConverter<Servi
                                ServiceStatusHistoryItem[] value,
                                JsonSerializerOptions options)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(value);
+#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
@@ -63,6 +67,7 @@ public sealed class ServiceStatusHistoryItemArrayConverter : JsonConverter<Servi
         {
             throw new ArgumentNullException(nameof(value));
         }
+#endif
 
         writer.WriteStartArray();
 

--- a/src/Aydsko.iRacingData/Converters/StatusTimeStampConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/StatusTimeStampConverter.cs
@@ -25,10 +25,14 @@ public sealed class StatusTimeStampConverter : JsonConverter<DateTimeOffset>
                                DateTimeOffset value,
                                JsonSerializerOptions options)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(writer);
+#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
+#endif
 
         if (value is DateTimeOffset instant)
         {

--- a/src/Aydsko.iRacingData/Converters/TenThousandthSecondDurationConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/TenThousandthSecondDurationConverter.cs
@@ -34,10 +34,14 @@ public sealed class TenThousandthSecondDurationConverter : JsonConverter<TimeSpa
                                TimeSpan? value,
                                JsonSerializerOptions options)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(writer);
+#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
+#endif
 
         if (value is null)
         {

--- a/src/Aydsko.iRacingData/Converters/UriConverter.cs
+++ b/src/Aydsko.iRacingData/Converters/UriConverter.cs
@@ -26,10 +26,14 @@ public sealed class UriConverter : JsonConverter<Uri>
                                Uri value,
                                JsonSerializerOptions options)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(writer);
+#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
+#endif
 
         if (value is null)
         {

--- a/src/Aydsko.iRacingData/IDataClient.cs
+++ b/src/Aydsko.iRacingData/IDataClient.cs
@@ -671,4 +671,25 @@ public interface IDataClient
     /// <exception cref="iRacingDataClientException">If there's a problem processing the result.</exception>
     /// <exception cref="iRacingUnauthorizedResponseException">If the iRacing API returns a <c>401 Unauthorized</c> response.</exception>
     Task<DataResponse<SpectatorSubsessionIds>> GetSpectatorSubsessionIdentifiersAsync(Common.EventType[]? eventTypes = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Build a collection of URIs which resolve to screenshots of the track.</summary>
+    /// <param name="track">The track detail for the circuit you want screenshots for.</param>
+    /// <param name="trackAssets">The related track assets detail for the same circuit as <paramref name="track"/>.</param>
+    /// <returns>A collection of <see cref="Uri"/> objects containing links that will resolve to images of the track or an empty collection.</returns>
+    /// <exception cref="ArgumentNullException">Either <paramref name="track"/> or <paramref name="trackAssets"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// One of these issues will cause this exception:
+    /// <list type="bullet">
+    /// <item><see cref="Tracks.Track.TrackId"/> and <see cref="Tracks.TrackAssets.TrackId"/> properties do not have the same value.</item>
+    /// <item><see cref="Tracks.TrackAssets.TrackMap"/> property is not a valid absolute URI.</item>
+    /// </list>
+    /// </exception>
+    IEnumerable<Uri> GetTrackAssetScreenshotUris(Tracks.Track track, TrackAssets trackAssets);
+
+    /// <summary>Build a collection of URIs which resolve to screenshots of the track.</summary>
+    /// <param name="trackId">The unique identifier of the track for which the screenshot links should be generated.</param>
+    /// <param name="cancellationToken">A token to allow the operation to be cancelled.</param>
+    /// <returns>A <see cref="Task"/> that resolves to a collection of <see cref="Uri"/> objects containing links to images of the track or an empty collection.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="trackId"/> value given could not be resolved to a valid track or located in the track assets.</exception>
+    Task<IEnumerable<Uri>> GetTrackAssetScreenshotUrisAsync(int trackId, CancellationToken cancellationToken = default);
 }

--- a/src/Aydsko.iRacingData/Package Release Notes.txt
+++ b/src/Aydsko.iRacingData/Package Release Notes.txt
@@ -2,3 +2,4 @@
 
  - Fixed parameter handling error which omitted some values from a Series Result Search request.
  - Support 2023 Season 3 Changes (Issue: #178)
+ - Move track screen shot URI generation on to "IDataClient" so it is more discoverable. (Issue: #177)

--- a/src/Aydsko.iRacingData/ServicesExtensions.cs
+++ b/src/Aydsko.iRacingData/ServicesExtensions.cs
@@ -115,7 +115,9 @@ public static class ServicesExtensions
 #endif
 
         services.TryAddSingleton(new CookieContainer());
+#pragma warning disable CS0618 // Type or member is obsolete
         services.TryAddTransient<TrackScreenshotService>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var options = new iRacingDataClientOptions();
         configureOptions.Invoke(options);

--- a/src/Aydsko.iRacingData/ServicesExtensions.cs
+++ b/src/Aydsko.iRacingData/ServicesExtensions.cs
@@ -17,12 +17,16 @@ public static class ServicesExtensions
     /// <exception cref="ArgumentNullException">One of the arguments is <see langword="null"/>.</exception>
     public static IServiceCollection AddIRacingDataApi(this IServiceCollection services)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(services);
+#else
         if (services is null)
         {
             throw new ArgumentNullException(nameof(services));
         }
+#endif
 
-        services.AddIRacingDataApiInternal(null, false);
+        services.AddIRacingDataApiInternal((_) => { }, false);
         return services;
     }
 
@@ -33,6 +37,10 @@ public static class ServicesExtensions
     /// <exception cref="ArgumentNullException">One of the arguments is <see langword="null"/>.</exception>
     public static IServiceCollection AddIRacingDataApi(this IServiceCollection services, Action<iRacingDataClientOptions> configureOptions)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+#else
         if (services is null)
         {
             throw new ArgumentNullException(nameof(services));
@@ -42,6 +50,7 @@ public static class ServicesExtensions
         {
             throw new ArgumentNullException(nameof(configureOptions));
         }
+#endif
 
         services.AddIRacingDataApiInternal(configureOptions, false);
         return services;
@@ -53,12 +62,16 @@ public static class ServicesExtensions
     /// <exception cref="ArgumentNullException">One of the arguments is <see langword="null"/>.</exception>
     public static IServiceCollection AddIRacingDataApiWithCaching(this IServiceCollection services)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(services);
+#else
         if (services is null)
         {
             throw new ArgumentNullException(nameof(services));
         }
+#endif
 
-        services.AddIRacingDataApiInternal(null, true);
+        services.AddIRacingDataApiInternal((_) => { }, true);
         return services;
     }
 
@@ -69,6 +82,10 @@ public static class ServicesExtensions
     /// <exception cref="ArgumentNullException">One of the arguments is <see langword="null"/>.</exception>
     public static IServiceCollection AddIRacingDataApiWithCaching(this IServiceCollection services, Action<iRacingDataClientOptions> configureOptions)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+#else
         if (services is null)
         {
             throw new ArgumentNullException(nameof(services));
@@ -78,25 +95,30 @@ public static class ServicesExtensions
         {
             throw new ArgumentNullException(nameof(configureOptions));
         }
+#endif
 
         services.AddIRacingDataApiInternal(configureOptions, true);
         return services;
     }
 
     static internal IHttpClientBuilder AddIRacingDataApiInternal(this IServiceCollection services,
-                                                                 Action<iRacingDataClientOptions>? configureOptions,
+                                                                 Action<iRacingDataClientOptions> configureOptions,
                                                                  bool includeCaching)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(services);
+#else
         if (services is null)
         {
             throw new ArgumentNullException(nameof(services));
         }
+#endif
 
         services.TryAddSingleton(new CookieContainer());
         services.TryAddTransient<TrackScreenshotService>();
 
         var options = new iRacingDataClientOptions();
-        configureOptions?.Invoke(options);
+        configureOptions.Invoke(options);
         services.AddSingleton(options);
 
         var userAgentValue = CreateUserAgentValue(options);
@@ -117,10 +139,14 @@ public static class ServicesExtensions
 
     private static string CreateUserAgentValue(iRacingDataClientOptions options)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(options);
+#else
         if (options is null)
         {
             throw new ArgumentNullException(nameof(options));
         }
+#endif
 
         if (options.UserAgentProductName is not string userAgentProductName)
         {

--- a/src/Aydsko.iRacingData/Tracks/Track.cs
+++ b/src/Aydsko.iRacingData/Tracks/Track.cs
@@ -1,7 +1,6 @@
 ﻿// © 2023 Adrian Clark
 // This file is licensed to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Aydsko.iRacingData.Converters;
 
 namespace Aydsko.iRacingData.Tracks;

--- a/src/Aydsko.iRacingData/Tracks/TrackScreenshotService.cs
+++ b/src/Aydsko.iRacingData/Tracks/TrackScreenshotService.cs
@@ -27,6 +27,10 @@ public class TrackScreenshotService
     /// </exception>
     public static IEnumerable<Uri> GetScreenshotLinks(Track track, TrackAssets trackAssets)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(track);
+        ArgumentNullException.ThrowIfNull(trackAssets);
+#else
         if (track is null)
         {
             throw new ArgumentNullException(nameof(track));
@@ -36,6 +40,7 @@ public class TrackScreenshotService
         {
             throw new ArgumentNullException(nameof(trackAssets));
         }
+#endif
 
         if (track.TrackId != trackAssets.TrackId)
         {
@@ -81,10 +86,14 @@ public class TrackScreenshotService
     /// <exception cref="ArgumentNullException">The <paramref name="track"/> was passed as <see langword="null"/>.</exception>
     public async Task<IEnumerable<Uri>> GetScreenshotLinksAsync(Track track, CancellationToken cancellationToken = default)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(track);
+#else
         if (track is null)
         {
             throw new ArgumentNullException(nameof(track));
         }
+#endif
 
         var trackAssets = await GetTrackAssetsByIdAsync(track.TrackId, cancellationToken).ConfigureAwait(false);
 
@@ -98,10 +107,14 @@ public class TrackScreenshotService
     /// <exception cref="ArgumentNullException">The <paramref name="trackAssets"/> was passed as <see langword="null"/>.</exception>
     public async Task<IEnumerable<Uri>> GetScreenshotLinksAsync(TrackAssets trackAssets, CancellationToken cancellationToken = default)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(trackAssets);
+#else
         if (trackAssets is null)
         {
             throw new ArgumentNullException(nameof(trackAssets));
         }
+#endif
 
         var track = await GetTrackByIdAsync(trackAssets.TrackId, cancellationToken).ConfigureAwait(false);
 

--- a/src/Aydsko.iRacingData/Tracks/TrackScreenshotService.cs
+++ b/src/Aydsko.iRacingData/Tracks/TrackScreenshotService.cs
@@ -3,6 +3,7 @@
 namespace Aydsko.iRacingData.Tracks;
 
 /// <summary>Contains logic to build links for the screenshots available of tracks.</summary>
+[Obsolete("Use one of \"GetTrackAssetScreenshotUris\" or \"GetTrackAssetScreenshotUrisAsync\" on \"IDataService\".")]
 public class TrackScreenshotService
 {
     private readonly IDataClient dataClient;


### PR DESCRIPTION
Move the implementation of the track screen shot URI generation to the main "IDataClient" interface so that it is easier to discover for users.