### PR TITLE
Implement "SessionStatus" Enumeration

### DIFF
--- a/src/Aydsko.iRacingData/Leagues/Session.cs
+++ b/src/Aydsko.iRacingData/Leagues/Session.cs
@@ -96,7 +96,10 @@ public class Session
     public bool StartZone { get; set; }
 
     [JsonPropertyName("status")]
-    public int Status { get; set; }
+    public int StatusRaw { get; set; }
+
+    [JsonIgnore]
+    public SessionStatus Status { get => (SessionStatus)StatusRaw; set => StatusRaw = (int)value; }
 
     [JsonPropertyName("subsession_id")]
     public int SubSessionId { get; set; }

--- a/src/Aydsko.iRacingData/Leagues/SessionStatus.cs
+++ b/src/Aydsko.iRacingData/Leagues/SessionStatus.cs
@@ -1,0 +1,11 @@
+﻿namespace Aydsko.iRacingData.Leagues;
+
+/// <summary>Indicates the status of the league session.</summary>
+public enum SessionStatus
+{
+    Unknown = 0,
+    Future = 1,
+    InProgress = 2,
+    DidNotLaunch = 3,
+    Complete = 4
+}

--- a/src/Aydsko.iRacingData/Package Release Notes.txt
+++ b/src/Aydsko.iRacingData/Package Release Notes.txt
@@ -1,9 +1,7 @@
 ﻿Fixes / Changes:
 
- - Fixed parameter handling error which omitted some values from a Series Result Search request.
- - Support 2023 Season 3 Changes (Issue: #178)
- - Move track screen shot URI generation on to "IDataClient" so it is more discoverable. (Issue: #177)
- - Handle the security based changes from 2023 Season 3 Patch 1.
+ - BREAKING CHANGE: Enumeration added for League Session "Status" field. (Issue: 182)
+   - Previous "int" value available as "StatusRaw" property.
 
 
 


### PR DESCRIPTION
The "Status" field of the League Session as a fixed set of values. Update it to hold an enumeration to make those values more meaningful.

Fixes #182