### PR TITLE
Consider Client Logged In Cookies are Restored

### DIFF
--- a/src/Aydsko.iRacingData.IntegrationTests/BaseIntegrationFixture.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/BaseIntegrationFixture.cs
@@ -18,7 +18,7 @@ public abstract class BaseIntegrationFixture<TClient> : IDisposable
 
     internal TClient Client { get; set; } = default!;
 
-    protected iRacingDataClientOptions BaseSetUp()
+    protected virtual iRacingDataClientOptions BaseSetUp()
     {
         Configuration = new ConfigurationBuilder()
                                 .SetBasePath(TestContext.CurrentContext.TestDirectory)

--- a/src/Aydsko.iRacingData.IntegrationTests/Logins/LoginTests.cs
+++ b/src/Aydsko.iRacingData.IntegrationTests/Logins/LoginTests.cs
@@ -1,0 +1,39 @@
+﻿// © 2023 Adrian Clark
+// This file is licensed to you under the MIT license.
+
+using System.Net;
+using Aydsko.iRacingData.Exceptions;
+
+namespace Aydsko.iRacingData.IntegrationTests.Logins;
+
+internal sealed class LoginTests : BaseIntegrationFixture<DataClient>
+{
+    private CookieCollection? _cookiesToRestore;
+    private CookieCollection? _cookiesFromSave;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var options = BaseSetUp();
+        options.RestoreCookies = () => _cookiesToRestore ?? [];
+        options.SaveCookies = (cookies) => _cookiesFromSave = cookies;
+
+        Client = new DataClient(HttpClient, new TestLogger<DataClient>(), options, CookieContainer);
+    }
+
+    [Test]
+    public async Task TestFailedLoginFromBadCookieRestoreAsync()
+    {
+        _cookiesToRestore = [new Cookie("test", "test", "/", ".iracing.com")];
+        _cookiesFromSave = [new Cookie("test", "test", "/", "localhost")];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(async () => await Client.GetClubHistoryLookupsAsync(2022, 1).ConfigureAwait(false),
+                        Throws.Exception.InstanceOf<iRacingUnauthorizedResponseException>());
+
+            Assert.That(_cookiesFromSave, Is.Empty);
+            Assert.That(Client.IsLoggedIn, Is.False);
+        });
+    }
+}

--- a/src/Aydsko.iRacingData/Common/ErrorResponse.cs
+++ b/src/Aydsko.iRacingData/Common/ErrorResponse.cs
@@ -9,5 +9,8 @@ public class ErrorResponse
     public string? ErrorCode { get; set; }
 
     [JsonPropertyName("note")]
-    public string? ErrorDescription { get; set; }
+    public string? Note { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
 }

--- a/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
+++ b/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
@@ -9,6 +9,27 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Common.ErrorResponse.get_ErrorDescription</Target>
+    <Left>lib/net6.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Common.ErrorResponse.set_ErrorDescription(System.String)</Target>
+    <Left>lib/net6.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Exceptions.iRacingUnauthorizedResponseException.Create</Target>
+    <Left>lib/net6.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Aydsko.iRacingData.Member.MemberChartDataPoint.get_Day</Target>
     <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
     <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
@@ -72,6 +93,27 @@
     <Target>M:Aydsko.iRacingData.Tracks.Track.get_Opens</Target>
     <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
     <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Common.ErrorResponse.get_ErrorDescription</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Common.ErrorResponse.set_ErrorDescription(System.String)</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Exceptions.iRacingUnauthorizedResponseException.Create</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0008</DiagnosticId>

--- a/src/Aydsko.iRacingData/Exceptions/iRacingUnauthorizedResponseException.cs
+++ b/src/Aydsko.iRacingData/Exceptions/iRacingUnauthorizedResponseException.cs
@@ -8,9 +8,9 @@ namespace Aydsko.iRacingData.Exceptions;
 [Serializable]
 public class iRacingUnauthorizedResponseException : iRacingDataClientException
 {
-    public static iRacingUnauthorizedResponseException Create()
+    public static iRacingUnauthorizedResponseException Create(string? message)
     {
-        return new("The iRacing API returned an \"Unauthorized\" response code.");
+        return new($"The iRacing API returned an \"Unauthorized\" response code{(string.IsNullOrEmpty(message)?"":" with message \"" + message + "\"")}.");
     }
 
     public iRacingUnauthorizedResponseException()

--- a/src/Aydsko.iRacingData/LoggingExtensions.cs
+++ b/src/Aydsko.iRacingData/LoggingExtensions.cs
@@ -18,6 +18,10 @@ public static class LoggingExtensions
                                                                                                                new EventId(EventIdLoginSuccessful, nameof(LoginSuccessful)),
                                                                                                                "Authenticated successfully as {UserEmail}");
 
+    private static readonly Action<ILogger, string, Exception?> loginCookiesRestored = LoggerMessage.Define<string>(LogLevel.Information,
+                                                                                                                    new EventId(EventIdLoginSuccessful, nameof(LoginSuccessful)),
+                                                                                                                    "Authenticated successfully as {UserEmail} using restored cookies");
+
     private static readonly Action<ILogger, int?, int?, DateTimeOffset?, Exception?> rateLimitsUpdated = LoggerMessage.Define<int?, int?, DateTimeOffset?>(LogLevel.Debug,
                                                                                                                                                            new EventId(EventIdRateLimitsUpdated, nameof(RateLimitsUpdated)),
                                                                                                                                                            "Currently have {RateLimitRemaining} calls left from {RateLimitTotal} resetting at {RateLimitResetInstant}");
@@ -28,7 +32,7 @@ public static class LoggingExtensions
 
     private static readonly Action<ILogger, string?, Exception?> errorResponse = LoggerMessage.Define<string?>(LogLevel.Trace,
                                                                                                                new EventId(EventIdErrorResponseTrace, nameof(ErrorResponse)),
-                                                                                                               "Error response from iRacing API: {ErrorDescription}");
+                                                                                                               "Error response from iRacing API: {Note}");
 
     private static readonly Action<ILogger, int?, int?, HttpStatusCode?, string?, Exception?> failedToRetrieveChunkError = LoggerMessage.Define<int?, int?, HttpStatusCode?, string?>(LogLevel.Error,
                                                                                                                                                                                       new EventId(EventIdFailedToRetrieveChunkError, nameof(FailedToRetrieveChunkError)),
@@ -39,6 +43,11 @@ public static class LoggingExtensions
     public static void LoginSuccessful(this ILogger logger, string userEmail)
     {
         loginSuccessful(logger, userEmail, null);
+    }
+
+    public static void LoginCookiesRestored(this ILogger logger, string userEmail)
+    {
+        loginCookiesRestored(logger, userEmail, null);
     }
 
     public static void RateLimitsUpdated(this ILogger logger, int? rateLimitRemaining, int? rateLimit, DateTimeOffset? rateLimitResetInstant)

--- a/src/Aydsko.iRacingData/Package Release Notes.txt
+++ b/src/Aydsko.iRacingData/Package Release Notes.txt
@@ -14,6 +14,11 @@
 
  - Fix "Interval" property on "SubsessionChartLap" so it doesn't throw an exception when driver has been lapped, which is a valid situation.
 
+ - Fix "Implementing SaveCookies and RestoreCookies does not prevent unnecessary logins" (Issue: #186)
+   - If you implement the "SaveCookies" and "RestoreCookies" methods and the cookies are for the correct domain, then the library will not attempt to login again.
+
+
+
 Contributions:
 
  - From Tobias Zürcher (https://github.com/tobiaszuercher):


### PR DESCRIPTION
If a "RestoreCookies" method is supplied and the cookies returned include any which apply to our base URL, then consider the client already authenticated so it doesn't have to call the login endpoint again.

Fixes #186