### PR TITLE
Implement Locking for Authentication

### DIFF
--- a/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
@@ -1369,4 +1369,13 @@ public class CapturedResponseValidationTests : MockedHttpTestBase
                                       .And.Property(nameof(SpectatorSubsessionIds.Success)).EqualTo(true)
                                       .And.Property(nameof(SpectatorSubsessionIds.SubsessionIdentifiers)).Length.EqualTo(192));
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            sut?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
 }

--- a/src/Aydsko.iRacingData.UnitTests/CookiePersistenceTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/CookiePersistenceTests.cs
@@ -24,10 +24,10 @@ public class CookiePersistenceTests : MockedHttpTestBase
             Password = "obviously.fake.password.value",
         };
 
-        var sut = new DataClient(HttpClient,
-                                 new TestLogger<DataClient>(),
-                                 options,
-                                 CookieContainer);
+        using var sut = new DataClient(HttpClient,
+                                       new TestLogger<DataClient>(),
+                                       options,
+                                       CookieContainer);
 
         await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetLookupsSuccessfulAsync)).ConfigureAwait(false);
         await sut.GetLookupsAsync(CancellationToken.None).ConfigureAwait(false);
@@ -47,10 +47,10 @@ public class CookiePersistenceTests : MockedHttpTestBase
             Password = "obviously.fake.password.value",
         };
 
-        var sut = new DataClient(HttpClient,
-                                 new TestLogger<DataClient>(),
-                                 options,
-                                 CookieContainer);
+        using var sut = new DataClient(HttpClient,
+                                       new TestLogger<DataClient>(),
+                                       options,
+                                       CookieContainer);
 
         await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetLookupsSuccessfulAsync)).ConfigureAwait(false);
         await sut.GetLookupsAsync(CancellationToken.None).ConfigureAwait(false);
@@ -79,10 +79,10 @@ public class CookiePersistenceTests : MockedHttpTestBase
             SaveCookies = null,
         };
 
-        var sut = new DataClient(HttpClient,
-                                 new TestLogger<DataClient>(),
-                                 options,
-                                 CookieContainer);
+        using var sut = new DataClient(HttpClient,
+                                       new TestLogger<DataClient>(),
+                                       options,
+                                       CookieContainer);
 
         await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetLookupsSuccessfulAsync)).ConfigureAwait(false);
         await sut.GetLookupsAsync(CancellationToken.None).ConfigureAwait(false);

--- a/src/Aydsko.iRacingData.UnitTests/DataClientTrackAssetScreenshotUrisTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/DataClientTrackAssetScreenshotUrisTests.cs
@@ -107,4 +107,13 @@ internal sealed class DataClientTrackAssetScreenshotUrisTests : MockedHttpTestBa
             Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/04.jpg")));
         });
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            sut?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
 }

--- a/src/Aydsko.iRacingData.UnitTests/LoginViaOptionsTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/LoginViaOptionsTests.cs
@@ -27,10 +27,10 @@ public class PasswordEncodingTests : MockedHttpTestBase
             SaveCookies = null,
         };
 
-        var sut = new DataClient(HttpClient,
-                                 new TestLogger<DataClient>(),
-                                 options,
-                                 CookieContainer);
+        using var sut = new DataClient(HttpClient,
+                                       new TestLogger<DataClient>(),
+                                       options,
+                                       CookieContainer);
 
         await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetLookupsSuccessfulAsync)).ConfigureAwait(false);
         var lookups = await sut.GetLookupsAsync(CancellationToken.None).ConfigureAwait(false);
@@ -64,10 +64,10 @@ public class PasswordEncodingTests : MockedHttpTestBase
 
         await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetLookupsSuccessfulAsync)).ConfigureAwait(false);
 
-        var sut = new DataClient(HttpClient,
-                                 new TestLogger<DataClient>(),
-                                 options,
-                                 CookieContainer);
+        using var sut = new DataClient(HttpClient,
+                                       new TestLogger<DataClient>(),
+                                       options,
+                                       CookieContainer);
 
         sut.UseUsernameAndPassword(username, password, passwordIsEncoded);
 
@@ -100,10 +100,10 @@ public class PasswordEncodingTests : MockedHttpTestBase
 
         await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetLookupsSuccessfulAsync)).ConfigureAwait(false);
 
-        var sut = new DataClient(HttpClient,
-                                 new TestLogger<DataClient>(),
-                                 options,
-                                 CookieContainer);
+        using var sut = new DataClient(HttpClient,
+                                       new TestLogger<DataClient>(),
+                                       options,
+                                       CookieContainer);
 
         sut.UseUsernameAndPassword(username, password);
 
@@ -153,10 +153,10 @@ public class PasswordEncodingTests : MockedHttpTestBase
 
         await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetLookupsSuccessfulAsync), false).ConfigureAwait(false);
 
-        var sut = new DataClient(HttpClient,
-                                 new TestLogger<DataClient>(),
-                                 options,
-                                 CookieContainer);
+        using var sut = new DataClient(HttpClient,
+                                       new TestLogger<DataClient>(),
+                                       options,
+                                       CookieContainer);
 
         sut.UseUsernameAndPassword(username, password);
 

--- a/src/Aydsko.iRacingData.UnitTests/TrackScreenshotServiceTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/TrackScreenshotServiceTests.cs
@@ -6,21 +6,22 @@ namespace Aydsko.iRacingData.UnitTests;
 internal sealed class TrackScreenshotServiceTests : MockedHttpTestBase
 {
     // NUnit will ensure that "SetUp" runs before each test so these can all be forced to "null".
+    private DataClient dataClient = null!;
     private TrackScreenshotService sut = null!;
 
     [SetUp]
     public async Task SetUpAsync()
     {
         BaseSetUp();
-        var dataClient = new DataClient(HttpClient,
-                                        new TestLogger<DataClient>(),
-                                        new iRacingDataClientOptions()
-                                        {
-                                            Username = "test.user@example.com",
-                                            Password = "SuperSecretPassword",
-                                            CurrentDateTimeSource = () => new DateTimeOffset(2022, 04, 05, 0, 0, 0, TimeSpan.Zero)
-                                        },
-                                        new System.Net.CookieContainer());
+        dataClient = new DataClient(HttpClient,
+                                    new TestLogger<DataClient>(),
+                                    new iRacingDataClientOptions()
+                                    {
+                                        Username = "test.user@example.com",
+                                        Password = "SuperSecretPassword",
+                                        CurrentDateTimeSource = () => new DateTimeOffset(2022, 04, 05, 0, 0, 0, TimeSpan.Zero)
+                                    },
+                                    new System.Net.CookieContainer());
 
         // Make use of our captured responses.
         await MessageHandler.QueueResponsesAsync(nameof(CapturedResponseValidationTests.GetTracksSuccessfulAsync)).ConfigureAwait(false);
@@ -66,6 +67,15 @@ internal sealed class TrackScreenshotServiceTests : MockedHttpTestBase
             Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/03.jpg")));
             Assert.That(suzukaResults, Contains.Item(new Uri("https://dqfp1ltauszrc.cloudfront.net/public/track-maps-screenshots/114_screenshots/04.jpg")));
         });
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            dataClient?.Dispose();
+        }
+        base.Dispose(disposing);
     }
 }
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Aydsko.iRacingData/Package Release Notes.txt
+++ b/src/Aydsko.iRacingData/Package Release Notes.txt
@@ -19,6 +19,9 @@
 
  - "DataClient" class is now "public" so it can be used outside of the library. It is still recommended to resolve the "IDataClient" interface from the DI container in most situations.
 
+ - Fix "Auth concurrency issues" (Issue #185)
+   - The library now uses a semaphore to prevent multiple login attempts at the same time on the same instance of the "DataClient" class.
+
 
 
 Contributions:


### PR DESCRIPTION
It is possible on a particular DataClient instance to call multiple methods and have each method trigger the authentication process. This leads to the login calls being made multiple times, wasting API calls.

This change places a lock such that the login process will be called once regardless of how many methods attempt to access it at the same time.

Fixes: #185