### PR TITLE
Set Output Params Correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             PACKAGE_KEY: ${{ secrets.PACKAGE_UPLOAD }}
 
       - name: Delete Old Packages
-        uses: smartsquaregmbh/delete-old-packages@v0.6.0
+        uses: smartsquaregmbh/delete-old-packages@v0.7.0
         with:
           user: AdrianJSClark
           type: nuget

--- a/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
+++ b/src/Aydsko.iRacingData/Aydsko.iRacingData.csproj
@@ -98,7 +98,7 @@
       <IsPreReleaseBuild>true</IsPreReleaseBuild>
       <IsPreReleaseBuild Condition="'$(MinVerPreRelease)' == ''">false</IsPreReleaseBuild>
     </PropertyGroup>
-    <Exec Command="echo ::set-output name=BUILDVERSION::$(MinVerVersion)" IgnoreExitCode="true" />
-    <Exec Command="echo ::set-output name=PRERELEASE::$(IsPreReleaseBuild)" IgnoreExitCode="true" />
+    <Exec Command="echo &quot;BUILDVERSION=$(MinVerVersion)&quot; >> &quot;$GITHUB_OUTPUT&quot;" IgnoreExitCode="true" />
+    <Exec Command="echo &quot;PRERELEASE=$(IsPreReleaseBuild)&quot; >> &quot;$GITHUB_OUTPUT&quot;" IgnoreExitCode="true" />
   </Target>
 </Project>


### PR DESCRIPTION
Update from "set-output" which is deprecated to the "GITHUB_OUTPUT" environment file.