### PR TITLE
Use Cookies Even Without "RestoreCookies"

### DIFF
--- a/src/Aydsko.iRacingData/DataClient.cs
+++ b/src/Aydsko.iRacingData/DataClient.cs
@@ -1869,14 +1869,14 @@ public class DataClient(HttpClient httpClient,
                 && options.RestoreCookies() is CookieCollection savedCookies)
             {
                 cookieContainer.Add(savedCookies);
+            }
 
-                // Assume we're logged in if we have cookies for our target domain
-                if (cookieContainer.GetCookies(new Uri("https://members-ng.iracing.com")).Count > 0)
-                {
-                    IsLoggedIn = true;
-                    logger.LoginCookiesRestored(options.Username!);
-                    return;
-                }
+            // Assume we're logged in if we have cookies for our target domain
+            if (cookieContainer.GetCookies(new Uri("https://members-ng.iracing.com")).Count > 0)
+            {
+                IsLoggedIn = true;
+                logger.LoginCookiesRestored(options.Username!);
+                return;
             }
 
             string? encodedHash = null;


### PR DESCRIPTION
Previously the code only checked the cookie container for relevant cookies if the "RestoreCookies" delegate was configured. This means that if the cookie container was populated some other way then the login process would be called again.

Move the check for cookies which might be existing, valid authentication outside the check for "RestoreCookies" delegate to take advantage of any data the collection already contains.

Fixes: #200 