### PR TITLE
[fix] 213 - Library Considers Itself "Logged In" Despite Authentication Exception

### DIFF
--- a/src/Aydsko.iRacingData/DataClient.cs
+++ b/src/Aydsko.iRacingData/DataClient.cs
@@ -1933,9 +1933,8 @@ public class DataClient(HttpClient httpClient,
             }
 
             var cookies = cookieContainer.GetCookies(new Uri("https://members-ng.iracing.com"));
-            var active = cookies.Cast<Cookie>().Any(cookie => !cookie.Expired);
-            // Assume we're logged in if we have any active cookies for our target domain
-            if (active)
+            var authenticated = cookies["authtoken_members"] is { Expired: false };
+            if (authenticated)
             {
                 IsLoggedIn = true;
                 logger.LoginCookiesRestored(options.Username!);

--- a/src/Aydsko.iRacingData/DataClient.cs
+++ b/src/Aydsko.iRacingData/DataClient.cs
@@ -1902,7 +1902,7 @@ public class DataClient(HttpClient httpClient,
             {
                 if (IsLoggedIn is false)
                 {
-                    await LoginInternalAsync(cancellationToken).ConfigureAwait(false); 
+                    await LoginInternalAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
             finally
@@ -1932,8 +1932,10 @@ public class DataClient(HttpClient httpClient,
                 cookieContainer.Add(savedCookies);
             }
 
-            // Assume we're logged in if we have cookies for our target domain
-            if (cookieContainer.GetCookies(new Uri("https://members-ng.iracing.com")).Count > 0)
+            var cookies = cookieContainer.GetCookies(new Uri("https://members-ng.iracing.com"));
+            var active = cookies.Cast<Cookie>().Any(cookie => !cookie.Expired);
+            // Assume we're logged in if we have any active cookies for our target domain
+            if (active)
             {
                 IsLoggedIn = true;
                 logger.LoginCookiesRestored(options.Username!);
@@ -2269,7 +2271,7 @@ public class DataClient(HttpClient httpClient,
             throw new ArgumentNullException(nameof(url), "URL must be supplied");
         }
 #endif
-        
+
         var data = await httpClient.GetFromJsonAsync(url, WeatherForecastArrayContext.Default.ListWeatherForecast, cancellationToken: cancellationToken)
                          .ConfigureAwait(false)
                      ?? throw new iRacingDataClientException("Data not found.");


### PR DESCRIPTION
This one bit me this week so I thought I'd put together a quick patch ... worst comes to worst it might be a jumping off point.

* Added a filter that excludes expired cookies when checking for active iracing cookies. 
* Added a unit test that checks that the expired cookies 

Sorry for the formatting changes, I tried to get my settings as close to yours as I could, looks like i failed.