### PR TITLE
Change precipitation chance to decimal

### DIFF
--- a/src/Aydsko.iRacingData/Series/WeatherSummary.cs
+++ b/src/Aydsko.iRacingData/Series/WeatherSummary.cs
@@ -9,7 +9,7 @@ public class WeatherSummary
     public string? MaxPrecipitationRateDesc { get; set; }
 
     [JsonPropertyName("precip_chance")]
-    public int PrecipitationChance { get; set; }
+    public decimal PrecipitationChance { get; set; }
 
     [JsonPropertyName("skies_high")]
     public int SkiesHigh { get; set; }


### PR DESCRIPTION
Change because the current calendar contains precipitation chances with a decimal value and this cannot be deserialised