### PR TITLE
Handle the "Legacy Authentication" Setting

### DIFF
--- a/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
@@ -959,6 +959,27 @@ internal sealed class CapturedResponseValidationTests : MockedHttpTestBase
     }
 
     [Test(TestOf = typeof(DataClient))]
+    public async Task GetSubSessionResultUnauthorizedDueToLegacyAuthenticationSettingThrowsErrorsAsync()
+    {
+        await MessageHandler.QueueResponsesAsync("ResponseUnauthorizedLegacyRequired", false).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            var loginFailedException = Assert.ThrowsAsync<iRacingLoginFailedException>(async () =>
+            {
+                var lapChartResponse = await sut.GetSubSessionResultAsync(12345, false).ConfigureAwait(false);
+            });
+
+            if (loginFailedException != null)
+            {
+                Assert.That(loginFailedException.LegacyAuthenticationRequired, Is.True);
+            }
+
+            Assert.That(sut.IsLoggedIn, Is.False);
+        });
+    }
+
+    [Test(TestOf = typeof(DataClient))]
     public async Task GetSubsessionEventLogSuccessfulAsync()
     {
         await MessageHandler.QueueResponsesAsync(nameof(GetSubsessionEventLogSuccessfulAsync)).ConfigureAwait(false);

--- a/src/Aydsko.iRacingData.UnitTests/MockedHttpMessageHandler.cs
+++ b/src/Aydsko.iRacingData.UnitTests/MockedHttpMessageHandler.cs
@@ -2,8 +2,10 @@
 // This file is licensed to you under the MIT license.
 
 using System.Net;
+#if !NET6_0_OR_GREATER
 using System.Net.Http;
 using System.Net.Http.Json;
+#endif
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
@@ -67,7 +69,7 @@ internal sealed class MockedHttpMessageHandler(CookieContainer cookieContainer)
     {
         var manifestResourceNames = (prefixLoginResponse ? SuccessfulLoginResponse : [])
                                     .Concat(ResourceAssembly.GetManifestResourceNames()
-                                                            .Where(mrn => mrn.StartsWith($"Aydsko.iRacingData.UnitTests.Responses.{testName}", StringComparison.InvariantCultureIgnoreCase)));
+                                                            .Where(mrn => mrn.StartsWith($"Aydsko.iRacingData.UnitTests.Responses.{testName}.", StringComparison.InvariantCultureIgnoreCase)));
 
         foreach (var manifestName in manifestResourceNames)
         {

--- a/src/Aydsko.iRacingData.UnitTests/Responses/ResponseUnauthorizedLegacyRequired/0.json
+++ b/src/Aydsko.iRacingData.UnitTests/Responses/ResponseUnauthorizedLegacyRequired/0.json
@@ -1,0 +1,8 @@
+{
+  "statuscode": 401,
+  "headers": { },
+  "content": {
+    "error": "access_denied",
+    "error_description": "legacy authorization refused"
+  }
+}

--- a/src/Aydsko.iRacingData/Common/ErrorResponse.cs
+++ b/src/Aydsko.iRacingData/Common/ErrorResponse.cs
@@ -13,4 +13,7 @@ public class ErrorResponse
 
     [JsonPropertyName("message")]
     public string? Message { get; set; }
+
+    [JsonPropertyName("error_description")]
+    public string? ErrorDescription { get; set; }
 }

--- a/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
+++ b/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
@@ -37,6 +37,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Exceptions.iRacingLoginFailedException.Create(System.String,System.Nullable{System.Boolean})</Target>
+    <Left>lib/net6.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Aydsko.iRacingData.Hosted.Car.get_PowerAdjustPercent</Target>
     <Left>lib/net6.0/Aydsko.iRacingData.dll</Left>
     <Right>lib/net6.0/Aydsko.iRacingData.dll</Right>
@@ -80,6 +87,13 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Aydsko.iRacingData.DataClient.GetLeaguePointsSystemsAsync(System.Int32,System.Nullable{System.Int32},System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/net8.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Exceptions.iRacingLoginFailedException.Create(System.String,System.Nullable{System.Boolean})</Target>
     <Left>lib/net8.0/Aydsko.iRacingData.dll</Left>
     <Right>lib/net8.0/Aydsko.iRacingData.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -195,6 +209,13 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Aydsko.iRacingData.DataClient.GetLeaguePointsSystemsAsync(System.Int32,System.Nullable{System.Int32},System.Threading.CancellationToken)</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Aydsko.iRacingData.Exceptions.iRacingLoginFailedException.Create(System.String,System.Nullable{System.Boolean})</Target>
     <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
     <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Aydsko.iRacingData/Exceptions/iRacingLoginFailedException.cs
+++ b/src/Aydsko.iRacingData/Exceptions/iRacingLoginFailedException.cs
@@ -8,15 +8,18 @@ namespace Aydsko.iRacingData.Exceptions;
 [Serializable]
 public class iRacingLoginFailedException : iRacingDataClientException
 {
+    /// <summary>Indicates the account requires the user to authenticate via a browser to complete a CAPTCHA or contact iRacing Support.</summary>
     public bool? VerificationRequired { get; private set; }
+    /// <summary>If set to <see langword="true"/> the user account must be configured for &quot;Legacy Authentication&quot; to bypass multi-factor authentication.</summary>
+    public bool? LegacyAuthenticationRequired { get; private set; }
 
-    public static iRacingLoginFailedException Create(string? message, bool? verificationRequired = null)
+    public static iRacingLoginFailedException Create(string? message, bool? verificationRequired = null, bool? legacyAuthenticationRequired = null)
     {
         var exceptionMessage = message ?? "Login to iRacing failed.";
 
-        return verificationRequired is null
+        return verificationRequired is null && legacyAuthenticationRequired is null
             ? new iRacingLoginFailedException(exceptionMessage)
-            : new iRacingLoginFailedException(exceptionMessage, verificationRequired.Value);
+            : new iRacingLoginFailedException(exceptionMessage, verificationRequired ?? false, legacyAuthenticationRequired ?? false);
     }
 
     public static iRacingLoginFailedException Create(Exception ex)
@@ -34,6 +37,13 @@ public class iRacingLoginFailedException : iRacingDataClientException
         : base(message)
     {
         VerificationRequired = verificationRequired;
+    }
+
+    public iRacingLoginFailedException(string message, bool verificationRequired, bool legacyAuthenticationRequired)
+        : base(message)
+    {
+        VerificationRequired = verificationRequired;
+        LegacyAuthenticationRequired = legacyAuthenticationRequired;
     }
 
     public iRacingLoginFailedException(string message, Exception inner)

--- a/src/Aydsko.iRacingData/Package Release Notes.txt
+++ b/src/Aydsko.iRacingData/Package Release Notes.txt
@@ -3,3 +3,14 @@ Fixes / Changes:
 - Season Driver Standings Deserialization Failure (Issue #224)
     Fixed an issue where the "SeasonDriverStandings" deserialization would fail
     due to the "avg_start_position" property containing non-integer data.
+
+- Support "Legacy Authentication" Setting Failure Response (Issue #223)
+    Added support for the "Legacy Authentication" setting in the iRacing
+    account settings. This setting will be required to login to the
+    "/data API" after iRacing enables multi-factor authentication (aka "2FA").
+
+    If the setting is not enabled, an "iRacingLoginFailedException" will be
+    thrown when attempting to login with the new "LegacyAuthenticationRequired"
+    property set to "true" and the following message:
+
+    Access was denied with message \"legacy authorization refused"


### PR DESCRIPTION
iRacing will require a separate setting to turn off multi-factor authentication after it is introduced, so that simple username and password authentication can continue before they start enabling people to register OAuth applications.