### PR TITLE
Include "FlairId" and "FlairName" properties on "Result" type

### DIFF
--- a/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
+++ b/src/Aydsko.iRacingData.UnitTests/CapturedResponseValidationTests.cs
@@ -799,6 +799,8 @@ internal sealed class CapturedResponseValidationTests
             Assert.That(sampleDriver.CarName, Is.EqualTo("Cadillac CTS-V Racecar"));
             Assert.That(sampleDriver.DivisionName, Is.EqualTo("Division 1"));
             Assert.That(sampleDriver.CountryCode, Is.EqualTo("AU"));
+            Assert.That(sampleDriver.FlairId, Is.EqualTo(1));
+            Assert.That(sampleDriver.FlairName, Is.EqualTo("Unaffiliated"));
 
             Assert.That(subSessionResult.Weather, Is.Not.Null);
 

--- a/src/Aydsko.iRacingData.UnitTests/Responses/GetSubSessionResultSuccessfulAsync/2.json
+++ b/src/Aydsko.iRacingData.UnitTests/Responses/GetSubSessionResultSuccessfulAsync/2.json
@@ -188,6 +188,8 @@
             "drop_race": false,
             "finish_position": 0,
             "finish_position_in_class": 0,
+            "flair_id": 16,
+						"flair_name": "Australia",
             "friend": false,
             "helmet": {
               "pattern": 9,
@@ -1945,6 +1947,8 @@
             "drop_race": true,
             "finish_position": 0,
             "finish_position_in_class": 0,
+            "flair_id": 1,
+            "flair_name": "Unaffiliated",
             "friend": false,
             "helmet": {
               "pattern": 9,

--- a/src/Aydsko.iRacingData.UnitTests/Responses/GetSubSessionResultSuccessfulAsync/2.json
+++ b/src/Aydsko.iRacingData.UnitTests/Responses/GetSubSessionResultSuccessfulAsync/2.json
@@ -189,7 +189,7 @@
             "finish_position": 0,
             "finish_position_in_class": 0,
             "flair_id": 16,
-						"flair_name": "Australia",
+            "flair_name": "Australia",
             "friend": false,
             "helmet": {
               "pattern": 9,

--- a/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
+++ b/src/Aydsko.iRacingData/CompatibilitySuppressions.xml
@@ -104,6 +104,20 @@
     <Right>lib/net8.0/Aydsko.iRacingData.dll</Right>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>Aydsko.iRacingData, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Target>
+    <Left>lib/net8.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/net8.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0003</DiagnosticId>
+    <Target>Aydsko.iRacingData, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Target>
+    <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>
+    <Right>lib/netstandard2.0/Aydsko.iRacingData.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>M:Aydsko.iRacingData.IDataClient.GetCurrentSeasonLookupAsync(System.Threading.CancellationToken)</Target>
     <Left>lib/netstandard2.0/Aydsko.iRacingData.dll</Left>

--- a/src/Aydsko.iRacingData/Results/Result.cs
+++ b/src/Aydsko.iRacingData/Results/Result.cs
@@ -209,6 +209,12 @@ public class Result
     [JsonPropertyName("country_code")]
     public string? CountryCode { get; set; } = default!;
 
+    [JsonPropertyName("flair_id")]
+    public int FlairId { get; set; } = default!;
+
+    [JsonPropertyName("flair_name")]
+    public string? FlairName { get; set; } = default!;
+
     [JsonPropertyName("driver_results")]
     public DriverResult[]? DriverResults { get; set; }
 


### PR DESCRIPTION
Adds the "FlairId" and "FlairName" properties to the "Result" type, mapped to resp. the "flair_id" and "flair_name" fields of the "/data/results/get" endpoint.

Include these properties in the "CapturedResponseValidationTests/GetSubsessionResultSuccessfulAsync" test and related test data file "GetSubSessionResultSuccessfulAsync/2.json" to test the mapping.

This fixes #257 

Let me know if I need to change anything.

I hope it's okay to just create a pull request. I ran into this specific case while trying to parse some flair-based statistics for a (semi-)league. Thanks for the great library.